### PR TITLE
WD-22622 - feat: add coverage GitHub Action

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -28,7 +28,7 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-15939"
+  epic_key: "WD-20980"
 
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types. 
   # If label on the issue is not in specified list, this issue will be created as a Bug

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -123,10 +123,11 @@ jobs:
         run: yarn install
 
       - name: Produce TICS report
-        shell: bash
-        run: |
-          set -x
-          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
-          curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
-          . ./install_tics.sh
-          TICSQServer -project rocks-storefront -tmpdir /tmp/tics -branchdir .
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: rocks-storefront
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,131 @@
+name: Test coverage
+on:
+  schedule:
+    - cron: "0 22 * * 5"
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install JS dependencies
+        run: yarn install --immutable
+
+      - name: Run JS tests with coverage
+        run: |
+          yarn test-js --coverage
+          mv coverage/js/cobertura-coverage.xml coverage/cobertura-coverage.xml
+
+      - name: Install Python requirements
+        run: |
+          sudo pip3 install -r requirements.txt
+
+      - name: Install Python dependencies
+        run: sudo pip3 install coverage
+
+      - name: Run Python tests with coverage
+        run: |
+          SECRET_KEY=simplesecretkey coverage run --source=. -m unittest discover tests
+          coverage xml -o coverage/coverage.xml
+          coverage html -d coverage/python
+
+      - name: Zip coverage report
+        run: |
+          zip -r coverage/cobertura-coverage.zip coverage/cobertura-coverage.xml coverage/coverage.xml
+      
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rocks-storefront-coverage
+          path: coverage
+          retention-days: 1
+  
+  publish-coverage-report:
+      name: publish-coverage-report
+      runs-on: ubuntu-latest
+      needs: test
+      continue-on-error: true
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: gh-pages
+            token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Cleanup coverage directory
+          run: |
+            rm -rf coverage
+            mkdir coverage
+        - name: Download coverage report artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: rocks-storefront-coverage
+            path: coverage
+        # user git configs are needed for git commands to work
+        # actual authentication is done using secrets.GITHUB_TOKEN with write permission
+        - name: Set Git User
+          run: |
+            git config --global user.email "github-action@example.com"
+            git config --global user.name "GitHub Action"
+        - name: Push coverage Report
+          timeout-minutes: 3
+          run: |
+            git add .
+            git commit -m "workflow: update coverage report"
+            
+            # In case of another action job pushing to gh-pages while we are rebasing for the current job
+            while true; do
+              git pull --rebase
+              if [ $? -ne 0 ]; then
+                echo "Failed to rebase. Please review manually."
+                exit 1
+              fi
+  
+              git push
+              if [ $? -eq 0 ]; then
+                echo "Successfully pushed HTML report to repo."
+                exit 0
+              fi
+            done
+        - name: Output Report URL as Worfklow Annotation
+          run: |
+            FULL_HTML_REPORT_URL=https://canonical.github.io/rocks-storefront/coverage
+            echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
+
+
+  tics-report:
+    runs-on: ubuntu-latest
+    needs: publish-coverage-report
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rocks-storefront-coverage
+          path: coverage
+
+      - name: Install Python requirements
+        run: |
+          sudo pip3 install -r requirements.txt
+
+      - name: Install Python dependencies
+        run: sudo pip3 install pylint
+
+      - name: Install JS dependencies
+        run: yarn install
+
+      - name: Produce TICS report
+        shell: bash
+        run: |
+          set -x
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+          curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
+          . ./install_tics.sh
+          TICSQServer -project rocks-storefront -tmpdir /tmp/tics -branchdir .

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Test coverage
 on:
   schedule:
     - cron: "0 22 * * 5"
+  pull_request:
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ venv/
 .dotrun.json
 .venv*/
 
+coverage/
 node_modules/
 bower_components/
 *.log

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ The application will be reporting errors to your `sentry.io` project from now on
 
 ## Testing
 
-Install the [`dotrun`](https://snapcraft.io/dotrun) snap.
+Install the [`dotrun`](https://snapcraft.io/dotrun) utility.
 
 ``` bash
 dotrun test


### PR DESCRIPTION
## Done

Add GitHub action to run the tests and upload the coverage reports to GitHub Pages and to TIOBE.

## How to QA

- I opened a draft PR with the "on: pull_request" trigger in the .github/coverage.yml file.
- The GitHub Action ran.
- The coverage result is available in the specified page at https://canonical.github.io/rocks-storefront/coverage.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): it's just a GitHub Action

## Issue / Card
Fixes [WD-22622](https://warthogs.atlassian.net/browse/WD-22622)

