### PR TITLE
WD-37347 - Logging

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -33,3 +33,45 @@ catch-all, `StoreApiConnectionError` covers the 5xx family). The `Message ||
 message` fallback matches the Python client's `if not message` behavior. Only
 the error types actually thrown by the rocks client are kept; the broader
 Python catalogue is trimmed to avoid dead exports.
+> Documentation of feature-level decisions for error handling. Each section
+> below records one feature: its approach and, where relevant, why.
+
+## Structured request logging with pino
+
+**Approach:** Logging is centralized in `src/hooks.server.ts`, which emits
+exactly one structured JSON line per request to stdout — no per-component
+logging. The deployment platform captures stdout and forwards it to the log
+store (Loki in COS).
+
+- Base logger: `src/lib/server/logger.ts` exposes a `createLogger()` factory and
+  a process-wide `logger` singleton. Level comes from `LOG_LEVEL`
+  (`$env/dynamic/private`, default `info`). Production emits raw JSON; dev uses
+  the `pino-pretty` transport. The factory accepts a `destination` stream so
+  tests capture output synchronously.
+- Correlation: `src/lib/server/correlation.ts` derives a `requestId` (reusing a
+  validated inbound `X-Request-Id`, else a generated UUID) and a `traceId`
+  (parsed from a W3C `traceparent` header, else a generated 16-byte hex id).
+- `handle` (`src/hooks.server.ts`) builds a child logger bound with
+  `requestId`/`traceId`, attaches it plus the ids to `event.locals`
+  (`log`/`requestId`/`traceId`, typed in `src/app.d.ts`), echoes `X-Request-Id`
+  on the response, and logs one line on completion with `method`, `path` (no
+  query string), `status`, and `durationMs`.
+- `handleError` logs uncaught server errors at `error` level with the request's
+  correlation ids (reusing the bound child logger when present) and returns only
+  a generic message to the client.
+- Redaction: a curated `err` serializer (`serializeError`) whitelists only
+  `type`/`message`/`stack`/`statusCode`, plus defensive `redact` paths for
+  common credential/cookie/header keys. The hooks log only curated fields, never
+  bodies, cookies, or auth headers.
+
+**Why:** Centralizing in hooks guarantees one consistent, correlatable line per
+request and keeps secrets out of logs by construction. Pino was chosen for log
+levels, async output, child loggers, and built-in OpenTelemetry/Sentry
+integration for later observability work. The `err` serializer whitelists fields
+rather than relying on redact paths because pino's default error serializer
+copies all enumerable properties and `redact` wildcards cannot reach arbitrary
+nested shapes (e.g. an upstream HTTP client error carrying
+`config.headers.authorization` or `response.data`) — a whitelist makes the
+"no secrets/PII" guarantee hold regardless of error shape. Traces and metrics
+(OpenTelemetry) are deferred; `traceId` is already emitted so logs will correlate
+with Tempo traces once tracing lands.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -59,7 +59,7 @@ store (Loki in COS).
 - `handleError` logs uncaught server errors at `error` level with the request's
   correlation ids (reusing the bound child logger when present) and returns only
   a generic message to the client.
-- Redaction: a curated `err` serializer (`serializeError`) whitelists only
+- Redaction: a curated `err` serializer (`serializeError`) allowlists only
   `type`/`message`/`stack`/`statusCode`, plus defensive `redact` paths for
   common credential/cookie/header keys. The hooks log only curated fields, never
   bodies, cookies, or auth headers.
@@ -67,11 +67,11 @@ store (Loki in COS).
 **Why:** Centralizing in hooks guarantees one consistent, correlatable line per
 request and keeps secrets out of logs by construction. Pino was chosen for log
 levels, async output, child loggers, and built-in OpenTelemetry/Sentry
-integration for later observability work. The `err` serializer whitelists fields
+integration for later observability work. The `err` serializer allowlists fields
 rather than relying on redact paths because pino's default error serializer
 copies all enumerable properties and `redact` wildcards cannot reach arbitrary
 nested shapes (e.g. an upstream HTTP client error carrying
-`config.headers.authorization` or `response.data`) — a whitelist makes the
+`config.headers.authorization` or `response.data`) — an allowlist makes the
 "no secrets/PII" guarantee hold regardless of error shape. Traces and metrics
 (OpenTelemetry) are deferred; `traceId` is already emitted so logs will correlate
 with Tempo traces once tracing lands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "rocks-storefront",
       "version": "0.0.1",
       "dependencies": {
-        "valibot": "^1.4.2",
-        "pino": "^10.3.1"
+        "pino": "^10.3.1",
+        "valibot": "^1.4.2"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "rocks-storefront",
       "version": "0.0.1",
       "dependencies": {
-        "valibot": "^1.4.2"
+        "valibot": "^1.4.2",
+        "pino": "^10.3.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
@@ -20,6 +21,7 @@
         "@types/node": "^26.0.1",
         "@vitest/browser-playwright": "^4.1.8",
         "husky": "^9.1.7",
+        "pino-pretty": "^13.1.3",
         "playwright": "^1.60.0",
         "svelte": "^5.56.1",
         "svelte-check": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vitest-browser-svelte": "^2.1.1"
   },
   "dependencies": {
-    "valibot": "^1.4.2",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "valibot": "^1.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^26.0.1",
     "@vitest/browser-playwright": "^4.1.8",
     "husky": "^9.1.7",
+    "pino-pretty": "^13.1.3",
     "playwright": "^1.60.0",
     "svelte": "^5.56.1",
     "svelte-check": "^4.6.0",
@@ -43,6 +44,7 @@
     "vitest-browser-svelte": "^2.1.1"
   },
   "dependencies": {
-    "valibot": "^1.4.2"
+    "valibot": "^1.4.2",
+    "pino": "^10.3.1"
   }
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,13 +1,20 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+import type { Logger } from "pino";
+
 declare global {
   namespace App {
     // interface Error {}
-    // interface Locals {}
+    interface Locals {
+      /** Per-request child logger bound with requestId and traceId. */
+      log: Logger;
+      /** Correlation id for this request (inbound X-Request-Id or generated). */
+      requestId: string;
+      /** Trace id correlating logs with Tempo traces. */
+      traceId: string;
+    }
     // interface PageData {}
     // interface PageState {}
     // interface Platform {}
   }
 }
-
-export {};

--- a/src/hooks.server.spec.ts
+++ b/src/hooks.server.spec.ts
@@ -1,0 +1,175 @@
+import type { RequestEvent } from "@sveltejs/kit";
+import { describe, expect, it, vi } from "vitest";
+import { createLogger } from "$lib/server/logger";
+import { createHandle, createHandleError } from "./hooks.server";
+
+interface CapturedLogger {
+  logger: ReturnType<typeof createLogger>;
+  lines: () => Record<string, unknown>[];
+}
+
+function captureLogger(): CapturedLogger {
+  const chunks: string[] = [];
+  const logger = createLogger({
+    level: "debug",
+    destination: {
+      write: (chunk: string) => {
+        chunks.push(chunk);
+      },
+    },
+  });
+  return {
+    logger,
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+  };
+}
+
+function buildEvent(url: string, init?: RequestInit): RequestEvent {
+  const request = new Request(url, init);
+  return {
+    request,
+    url: new URL(url),
+    locals: {},
+  } as unknown as RequestEvent;
+}
+
+describe("createHandle", () => {
+  it("emits exactly one request line with the curated fields", async () => {
+    const captured = captureLogger();
+    const handle = createHandle(captured.logger);
+    const event = buildEvent("https://rockstore.io/rocks?secret=token");
+    const resolve = vi.fn(async () => new Response("ok", { status: 200 }));
+
+    await handle({ event, resolve });
+
+    const lines = captured.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      method: "GET",
+      path: "/rocks",
+      status: 200,
+    });
+    expect(lines[0].durationMs).toEqual(expect.any(Number));
+  });
+
+  it("does not log the query string", async () => {
+    const captured = captureLogger();
+    const handle = createHandle(captured.logger);
+    const event = buildEvent("https://rockstore.io/rocks?token=supersecret");
+    const resolve = vi.fn(async () => new Response("ok"));
+
+    await handle({ event, resolve });
+
+    const [line] = captured.lines();
+    expect(JSON.stringify(line)).not.toContain("supersecret");
+    expect(line.path).toBe("/rocks");
+  });
+
+  it("binds a child logger and correlation ids to event.locals", async () => {
+    const captured = captureLogger();
+    const handle = createHandle(captured.logger);
+    const event = buildEvent("https://rockstore.io/", {
+      headers: { "x-request-id": "req-123" },
+    });
+    const resolve = vi.fn(async () => new Response("ok"));
+
+    await handle({ event, resolve });
+
+    expect(event.locals.requestId).toBe("req-123");
+    expect(event.locals.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(event.locals.log).toBeDefined();
+  });
+
+  it("echoes the requestId in the response X-Request-Id header", async () => {
+    const captured = captureLogger();
+    const handle = createHandle(captured.logger);
+    const event = buildEvent("https://rockstore.io/", {
+      headers: { "x-request-id": "req-abc" },
+    });
+    const resolve = vi.fn(async () => new Response("ok"));
+
+    const response = await handle({ event, resolve });
+
+    expect(response.headers.get("x-request-id")).toBe("req-abc");
+  });
+
+  it("tags the line with the correlation ids", async () => {
+    const captured = captureLogger();
+    const handle = createHandle(captured.logger);
+    const event = buildEvent("https://rockstore.io/", {
+      headers: { "x-request-id": "req-xyz" },
+    });
+    const resolve = vi.fn(async () => new Response("ok"));
+
+    await handle({ event, resolve });
+
+    const [line] = captured.lines();
+    expect(line).toMatchObject({ requestId: "req-xyz" });
+    expect(line.traceId).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("createHandleError", () => {
+  it("logs a serialized error at error level with correlation ids", () => {
+    const captured = captureLogger();
+    const handleError = createHandleError(captured.logger);
+    const event = buildEvent("https://rockstore.io/rocks", {
+      headers: { "x-request-id": "req-err" },
+    });
+    const error = new Error("database exploded");
+
+    handleError({ error, event, status: 500, message: "Internal Error" });
+
+    const [line] = captured.lines();
+    expect(line.level).toBe(50);
+    expect(line).toMatchObject({ requestId: "req-err", status: 500 });
+    expect(line.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(line.err).toMatchObject({ message: "database exploded" });
+  });
+
+  it("reuses the request child logger and ids from locals when present", () => {
+    const captured = captureLogger();
+    const handleError = createHandleError(captured.logger);
+    const event = buildEvent("https://rockstore.io/rocks");
+    event.locals.log = captured.logger.child({
+      requestId: "bound-req",
+      traceId: "a".repeat(32),
+    });
+    event.locals.requestId = "bound-req";
+    event.locals.traceId = "a".repeat(32);
+
+    handleError({
+      error: new Error("boom"),
+      event,
+      status: 500,
+      message: "Internal Error",
+    });
+
+    const [line] = captured.lines();
+    expect(line).toMatchObject({
+      requestId: "bound-req",
+      traceId: "a".repeat(32),
+    });
+  });
+
+  it("returns a safe message that does not leak internals", () => {
+    const captured = captureLogger();
+    const handleError = createHandleError(captured.logger);
+    const event = buildEvent("https://rockstore.io/rocks");
+
+    const result = handleError({
+      error: new Error("secret stack detail"),
+      event,
+      status: 500,
+      message: "Internal Error",
+    });
+
+    expect(result).toEqual({ message: "Internal Error" });
+    expect(JSON.stringify(result)).not.toContain("secret stack detail");
+  });
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,76 @@
+import type { Handle, HandleServerError } from "@sveltejs/kit";
+import type { Logger } from "pino";
+import { resolveRequestId, resolveTraceId } from "$lib/server/correlation";
+import { logger } from "$lib/server/logger";
+
+const REQUEST_ID_HEADER = "x-request-id";
+
+/**
+ * Build the `handle` hook bound to a base logger. A child logger carrying the
+ * request's `requestId`/`traceId` is attached to `event.locals` for downstream
+ * server code, and a single curated JSON line is emitted once the response is
+ * ready. The base logger is injected so tests can capture output.
+ */
+export function createHandle(baseLogger: Logger): Handle {
+  return async ({ event, resolve }) => {
+    const requestId = resolveRequestId(event.request.headers);
+    const traceId = resolveTraceId(event.request.headers);
+    const log = baseLogger.child({ requestId, traceId });
+
+    event.locals.log = log;
+    event.locals.requestId = requestId;
+    event.locals.traceId = traceId;
+
+    const start = performance.now();
+    const response = await resolve(event);
+    const durationMs = Math.round(performance.now() - start);
+
+    response.headers.set(REQUEST_ID_HEADER, requestId);
+
+    log.info(
+      {
+        method: event.request.method,
+        path: event.url.pathname,
+        status: response.status,
+        durationMs,
+      },
+      "request completed",
+    );
+
+    return response;
+  };
+}
+
+export const handle = createHandle(logger);
+
+/**
+ * Build the `handleError` hook bound to a base logger. Uncaught server errors
+ * are serialized (via pino's error serializer) and logged with the request's
+ * correlation ids, reusing the child logger bound in `handle` when available.
+ * The client only receives a generic message — never error internals.
+ */
+export function createHandleError(baseLogger: Logger): HandleServerError {
+  return ({ error, event, status, message }) => {
+    const log =
+      event.locals?.log ??
+      baseLogger.child({
+        requestId:
+          event.locals?.requestId ?? resolveRequestId(event.request.headers),
+        traceId: event.locals?.traceId ?? resolveTraceId(event.request.headers),
+      });
+
+    log.error(
+      {
+        err: error,
+        status,
+        method: event.request.method,
+        path: event.url.pathname,
+      },
+      "unhandled request error",
+    );
+
+    return { message };
+  };
+}
+
+export const handleError = createHandleError(logger);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,9 +1,11 @@
 import type { Handle, HandleServerError } from "@sveltejs/kit";
 import type { Logger } from "pino";
-import { resolveRequestId, resolveTraceId } from "$lib/server/correlation";
+import {
+  REQUEST_ID_HEADER,
+  resolveRequestId,
+  resolveTraceId,
+} from "$lib/server/correlation";
 import { logger } from "$lib/server/logger";
-
-const REQUEST_ID_HEADER = "x-request-id";
 
 /**
  * Build the `handle` hook bound to a base logger. A child logger carrying the

--- a/src/lib/server/correlation.spec.ts
+++ b/src/lib/server/correlation.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { resolveRequestId, resolveTraceId } from "./correlation";
+
+function headers(init: Record<string, string> = {}): Headers {
+  return new Headers(init);
+}
+
+describe("resolveRequestId", () => {
+  it("reuses a valid inbound X-Request-Id header", () => {
+    const id = resolveRequestId(headers({ "x-request-id": "req-from-edge" }));
+
+    expect(id).toBe("req-from-edge");
+  });
+
+  it("generates a UUID when the header is absent", () => {
+    const id = resolveRequestId(headers());
+
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("ignores a blank header value", () => {
+    const id = resolveRequestId(headers({ "x-request-id": "   " }));
+
+    expect(id).not.toBe("   ");
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("rejects an id with out-of-charset characters and generates one instead", () => {
+    const id = resolveRequestId(
+      headers({ "x-request-id": "has spaces; and=junk" }),
+    );
+
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("rejects an excessively long id and generates one instead", () => {
+    const id = resolveRequestId(headers({ "x-request-id": "a".repeat(200) }));
+
+    expect(id).not.toBe("a".repeat(200));
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe("resolveTraceId", () => {
+  it("extracts the trace-id from a valid W3C traceparent", () => {
+    const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const id = resolveTraceId(
+      headers({ traceparent: `00-${traceId}-00f067aa0ba902b7-01` }),
+    );
+
+    expect(id).toBe(traceId);
+  });
+
+  it("generates a 16-byte hex id when the header is missing", () => {
+    const id = resolveTraceId(headers());
+
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("generates a hex id when traceparent is malformed", () => {
+    const id = resolveTraceId(headers({ traceparent: "not-a-valid-header" }));
+
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("rejects the all-zero invalid trace-id and generates one instead", () => {
+    const id = resolveTraceId(
+      headers({
+        traceparent: "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+      }),
+    );
+
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+    expect(id).not.toBe("00000000000000000000000000000000");
+  });
+});

--- a/src/lib/server/correlation.ts
+++ b/src/lib/server/correlation.ts
@@ -1,0 +1,51 @@
+const REQUEST_ID_HEADER = "x-request-id";
+const TRACEPARENT_HEADER = "traceparent";
+
+/**
+ * W3C traceparent: "version-traceId-parentId-flags", e.g.
+ * 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01.
+ * We only consume the 32-hex-char trace-id segment.
+ */
+const TRACEPARENT_PATTERN =
+  /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/;
+const INVALID_TRACE_ID = "0".repeat(32);
+
+/**
+ * Accept an inbound request id only if it is a sane, bounded token. This blocks
+ * header injection (CR/LF would make `Headers.set` throw a 500 when echoed) and
+ * unbounded values that would bloat every log line.
+ */
+const VALID_REQUEST_ID = /^[\w-]{1,128}$/;
+
+/**
+ * Derive a request id, reusing a valid inbound `X-Request-Id` (set by an
+ * upstream proxy/platform) so correlation survives across hops, otherwise
+ * generating a fresh UUID.
+ */
+export function resolveRequestId(headers: Headers): string {
+  const inbound = headers.get(REQUEST_ID_HEADER)?.trim();
+  return inbound && VALID_REQUEST_ID.test(inbound)
+    ? inbound
+    : crypto.randomUUID();
+}
+
+/**
+ * Derive a trace id from a valid W3C `traceparent` header so logs line up with
+ * Tempo traces, falling back to a generated 16-byte (32 hex char) id when the
+ * header is absent, malformed, or carries the all-zero invalid trace-id.
+ */
+export function resolveTraceId(headers: Headers): string {
+  const traceparent = headers.get(TRACEPARENT_HEADER)?.trim();
+  const match = traceparent?.match(TRACEPARENT_PATTERN);
+  const traceId = match?.[1];
+
+  if (traceId && traceId !== INVALID_TRACE_ID) {
+    return traceId;
+  }
+
+  return generateTraceId();
+}
+
+function generateTraceId(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}

--- a/src/lib/server/correlation.ts
+++ b/src/lib/server/correlation.ts
@@ -1,4 +1,4 @@
-const REQUEST_ID_HEADER = "x-request-id";
+export const REQUEST_ID_HEADER = "x-request-id";
 const TRACEPARENT_HEADER = "traceparent";
 
 /**

--- a/src/lib/server/logger.spec.ts
+++ b/src/lib/server/logger.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createLogger, REDACT_PATHS } from "./logger";
+
+interface CollectingStream {
+  write: (chunk: string) => void;
+  lines: () => Record<string, unknown>[];
+}
+
+function collectingStream(): CollectingStream {
+  const chunks: string[] = [];
+  return {
+    write: (chunk: string) => {
+      chunks.push(chunk);
+    },
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+  };
+}
+
+describe("createLogger", () => {
+  it("defaults to the info level", () => {
+    const logger = createLogger();
+
+    expect(logger.level).toBe("info");
+  });
+
+  it("honors an explicit level", () => {
+    const logger = createLogger({ level: "debug" });
+
+    expect(logger.level).toBe("debug");
+  });
+
+  it("does not emit logs below the configured level", () => {
+    const stream = collectingStream();
+    const logger = createLogger({ level: "warn", destination: stream });
+
+    logger.info("ignored");
+    logger.warn("kept");
+
+    const lines = stream.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ msg: "kept" });
+  });
+
+  it("writes valid JSON with the expected shape", () => {
+    const stream = collectingStream();
+    const logger = createLogger({ destination: stream });
+
+    logger.info({ requestId: "abc" }, "hello");
+
+    const [line] = stream.lines();
+    expect(line).toMatchObject({ requestId: "abc", msg: "hello" });
+    expect(line).toHaveProperty("level");
+    expect(line).toHaveProperty("time");
+  });
+
+  it("redacts sensitive fields", () => {
+    const stream = collectingStream();
+    const logger = createLogger({ destination: stream });
+
+    logger.info(
+      {
+        authorization: "Bearer secret-token",
+        cookie: "session=abc",
+        password: "hunter2",
+        safe: "visible",
+      },
+      "request",
+    );
+
+    const [line] = stream.lines();
+    expect(line.authorization).toBe("[REDACTED]");
+    expect(line.cookie).toBe("[REDACTED]");
+    expect(line.password).toBe("[REDACTED]");
+    expect(line.safe).toBe("visible");
+  });
+
+  it("does not leak nested secrets/PII from serialized error objects", () => {
+    const stream = collectingStream();
+    const logger = createLogger({ destination: stream });
+
+    // Mimic an upstream HTTP client error carrying request config and response body.
+    const error = Object.assign(new Error("Request failed"), {
+      config: { headers: { authorization: "Bearer super-secret-token" } },
+      response: {
+        data: { customerEmail: "buyer@example.com", pan: "4111111111111111" },
+      },
+    });
+
+    logger.error({ err: error }, "upstream failure");
+
+    const raw = JSON.stringify(stream.lines());
+    expect(raw).not.toContain("super-secret-token");
+    expect(raw).not.toContain("buyer@example.com");
+    expect(raw).not.toContain("4111111111111111");
+
+    const [line] = stream.lines();
+    expect(line.err).toMatchObject({
+      type: "Error",
+      message: "Request failed",
+    });
+  });
+
+  it("exposes the redact paths it protects", () => {
+    expect(REDACT_PATHS).toEqual(
+      expect.arrayContaining(["authorization", "cookie", "password"]),
+    );
+  });
+});

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -41,7 +41,7 @@ export interface CreateLoggerOptions {
  * Curated error serializer. Pino's default `err` serializer copies every
  * enumerable property of the error, which leaks secrets/PII when upstream
  * clients throw errors carrying request config (auth headers) or response
- * bodies (customer data). We whitelist only safe fields so no exotic nested
+ * bodies (customer data). We allowlist only safe fields so no exotic nested
  * shape can ever reach the log store.
  */
 export function serializeError(error: unknown): Record<string, unknown> {

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -1,0 +1,103 @@
+import pino, {
+  type DestinationStream,
+  type Logger,
+  type LoggerOptions,
+} from "pino";
+import { dev } from "$app/environment";
+import { env } from "$env/dynamic/private";
+
+/**
+ * Sensitive keys that must never reach the log store, redacted defensively on
+ * top of the curated fields we explicitly log. Covers common header, cookie and
+ * credential shapes regardless of where they appear in a log object.
+ */
+export const REDACT_PATHS = [
+  "authorization",
+  "cookie",
+  "password",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "*.authorization",
+  "*.cookie",
+  "headers.authorization",
+  "headers.cookie",
+  'headers["set-cookie"]',
+  "req.headers.authorization",
+  "req.headers.cookie",
+  'res.headers["set-cookie"]',
+];
+
+export interface CreateLoggerOptions {
+  /** Minimum level to emit. Defaults to "info". */
+  level?: string;
+  /** Use the human-readable pino-pretty transport (dev only). */
+  pretty?: boolean;
+  /** Destination stream override, primarily for tests. */
+  destination?: DestinationStream;
+}
+
+/**
+ * Curated error serializer. Pino's default `err` serializer copies every
+ * enumerable property of the error, which leaks secrets/PII when upstream
+ * clients throw errors carrying request config (auth headers) or response
+ * bodies (customer data). We whitelist only safe fields so no exotic nested
+ * shape can ever reach the log store.
+ */
+export function serializeError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return { message: typeof error === "string" ? error : "Unknown error" };
+  }
+
+  const serialized: Record<string, unknown> = {
+    type: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+
+  const status =
+    (error as { status?: unknown }).status ??
+    (error as { statusCode?: unknown }).statusCode;
+  if (typeof status === "number") {
+    serialized.statusCode = status;
+  }
+
+  return serialized;
+}
+
+/**
+ * Build a pino logger with the project's redaction policy applied. Production
+ * emits raw JSON to stdout; dev can opt into pino-pretty. Tests inject a
+ * destination stream to capture output synchronously.
+ */
+export function createLogger(options: CreateLoggerOptions = {}): Logger {
+  const { level = "info", pretty = false, destination } = options;
+
+  const loggerOptions: LoggerOptions = {
+    level,
+    redact: { paths: REDACT_PATHS, censor: "[REDACTED]" },
+    serializers: { err: serializeError },
+  };
+
+  if (destination) {
+    return pino(loggerOptions, destination);
+  }
+
+  if (pretty) {
+    loggerOptions.transport = {
+      target: "pino-pretty",
+      options: { colorize: true },
+    };
+  }
+
+  return pino(loggerOptions);
+}
+
+/**
+ * Process-wide base logger. Per-request child loggers (bound with requestId and
+ * traceId) are derived from this in hooks.server.ts.
+ */
+export const logger = createLogger({
+  level: env.LOG_LEVEL ?? "info",
+  pretty: dev,
+});


### PR DESCRIPTION
## Done

Add logging to the project via a basic `pino` logger that includes:
- Structured JSON output in production
- Pretty print output in development
- Guards against printing sensitive information
- Each log line includes incoming traceId and requestId

## How to QA

- Clone the branch
- Run the project with task 
- Visit the home page with the example
- See the log to verify that it outputs the request
 
## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-37347](https://warthogs.atlassian.net/browse/WD-37347)

## Screenshots

This is the chat with the OpenCode agent that I ran. Useful to verify how the AI process works for #73.
https://opncd.ai/share/d4bXZkpK

[WD-37347]: https://warthogs.atlassian.net/browse/WD-37347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ