### PR TITLE
Search categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "playwright": "1.61.1",
         "svelte": "5.56.4",
         "svelte-check": "4.7.2",
-        "sveltekit-search-params": "4.0.0",
         "typescript": "6.0.3",
         "vite": "8.1.3",
         "vitest": "4.1.10",
@@ -3016,17 +3015,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
-      }
-    },
-    "node_modules/sveltekit-search-params": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sveltekit-search-params/-/sveltekit-search-params-4.0.0.tgz",
-      "integrity": "sha512-zVejOWfr5rOrAVO1yQpPGsPQn5dSHpgxUcshWeyDdU4YYzaMF8euEw753L5L/BEFmkQvfp5R38DSwLcJbNPPhg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.12.0",
-        "svelte": "^5.0.0"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "playwright": "1.61.1",
     "svelte": "5.56.4",
     "svelte-check": "4.7.2",
-    "sveltekit-search-params": "4.0.0",
     "typescript": "6.0.3",
     "vite": "8.1.3",
     "vitest": "4.1.10",

--- a/src/lib/components/rock/RockList/RockList.svelte
+++ b/src/lib/components/rock/RockList/RockList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Heading } from "$lib/components/ui/Heading";
+  import SearchSuggestions from "$lib/components/ui/SearchSuggestions/SearchSuggestions.svelte";
   import type { RockFindResultItem } from "$lib/server/api/types";
   import RockCard from "./RockCard/RockCard.svelte";
   import "./styles.css";
@@ -11,9 +12,9 @@
   const { rocks }: Props = $props();
 </script>
 
-<Heading level={2} class="visually-hidden">Search results</Heading>
 
 {#if rocks.length > 0}
+    <Heading level={2} class="visually-hidden">Search results</Heading>
     <ul class="ds rocks-list">
         {#each rocks as rock (rock.name)}
             <li>
@@ -22,6 +23,12 @@
             </li>
         {/each}
     </ul>
+
+    {#if rocks.length < 5}
+        <SearchSuggestions title="Not quite what you are looking for?" />
+    {/if}
 {:else}
-    No results :(
+    <SearchSuggestions title="No results found" />
 {/if}
+
+<!-- TODO: generalize this component to show featured rocks -->

--- a/src/lib/components/rock/RockList/RockList.svelte.test.ts
+++ b/src/lib/components/rock/RockList/RockList.svelte.test.ts
@@ -21,8 +21,9 @@ describe("RockList.svelte", () => {
   it("shows the empty state when there are no rocks", async () => {
     const { container } = render(RockList, { rocks: [] });
 
-    expect(container.textContent).toContain("No results :(");
-    expect(container.querySelector("ul")).toBeNull();
+    expect(container.textContent).toContain("No results found");
+    expect(container.textContent).toContain("Contact us");
+    expect(container.querySelector("ul")).not.toBeNull();
   });
 
   it("gives the results a heading for screen readers", async () => {

--- a/src/lib/components/rock/RockList/styles.css
+++ b/src/lib/components/rock/RockList/styles.css
@@ -1,11 +1,8 @@
 .ds.rocks-list {
   list-style-type: "";
+  margin-block: 0 var(--dimension-800);
 
   hr {
     opacity: 30%;
-  }
-
-  li:last-child hr {
-    display: none;
   }
 }

--- a/src/lib/components/ssr-rendering.spec.ts
+++ b/src/lib/components/ssr-rendering.spec.ts
@@ -138,7 +138,8 @@ describe("RockList server rendering", () => {
   it("emits the empty state with no rocks", () => {
     const { body } = render(RockList, { props: { rocks: [] } });
 
-    expect(body).toContain("No results :(");
+    expect(body).toContain("No results found");
+    expect(body).toContain("Contact us");
   });
 });
 

--- a/src/lib/components/ui/SearchForm/SearchForm.svelte
+++ b/src/lib/components/ui/SearchForm/SearchForm.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-  import { SearchBox } from "@canonical/svelte-ds-app-launchpad";
+  import { Checkbox, SearchBox } from "@canonical/svelte-ds-app-launchpad";
   import { SpinnerIcon } from "@canonical/svelte-icons";
   import "./styles.css";
 
   export type Props = {
     name: string;
-    value?: string | null;
+    value?: string;
     loading?: boolean;
   };
 
   let { name, value = $bindable(), loading }: Props = $props();
 </script>
 
-<form class="ds search-form" data-sveltekit-keepfocus>
+<form id="search-form" class="ds search-form" data-sveltekit-keepfocus>
     <label class="visually-hidden" for={name}>Search rocks</label>
     <SearchBox
         id={name}
         {name}
-        bind:value={value as string}
+        bind:value
         placeholder="Search for a rock"
         aria-label="Search rocks"
     >

--- a/src/lib/components/ui/SearchForm/SearchForm.svelte
+++ b/src/lib/components/ui/SearchForm/SearchForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox, SearchBox } from "@canonical/svelte-ds-app-launchpad";
+  import { SearchBox } from "@canonical/svelte-ds-app-launchpad";
   import { SpinnerIcon } from "@canonical/svelte-icons";
   import "./styles.css";
 

--- a/src/lib/components/ui/SearchSuggestions/SearchSuggestions.svelte
+++ b/src/lib/components/ui/SearchSuggestions/SearchSuggestions.svelte
@@ -15,6 +15,7 @@
     <div class="options">
         You can:
         <ul>
+            <!-- TODO: add the correct href -->
             <li><a href="/">Contact us</a> to add a rock to our portfolio.</li>
             <li>Modify the filters applied to widen your search.</li>
             <li>Explore our categories to find alternatives.</li>

--- a/src/lib/components/ui/SearchSuggestions/SearchSuggestions.svelte
+++ b/src/lib/components/ui/SearchSuggestions/SearchSuggestions.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { Heading } from "../Heading";
+  import "./styles.css";
+
+  type Props = {
+    title: string;
+  };
+
+  const { title }: Props = $props();
+</script>
+
+<div class="ds search-suggestions">
+    <Heading level={2}>{title}</Heading>
+
+    <div class="options">
+        You can:
+        <ul>
+            <li><a href="/">Contact us</a> to add a rock to our portfolio.</li>
+            <li>Modify the filters applied to widen your search.</li>
+            <li>Explore our categories to find alternatives.</li>
+        </ul>
+    </div>
+</div>

--- a/src/lib/components/ui/SearchSuggestions/styles.css
+++ b/src/lib/components/ui/SearchSuggestions/styles.css
@@ -1,0 +1,19 @@
+.ds.search-suggestions {
+  margin-block: var(--space-300);
+
+  .heading {
+    margin-block: var(--space-300);
+    color: var(--color-text);
+    font-family: var(--typography-text-primary-font-family);
+    font-size: var(--typography-text-primary-font-size);
+    font-weight: var(--typography-weight-semiBold);
+    letter-spacing: var(--typography-text-primary-letter-spacing);
+    line-height: var(--typography-text-primary-line-height);
+  }
+
+  .options {
+    ul {
+      padding-inline-start: var(--space-400);
+    }
+  }
+}

--- a/src/lib/utils/searchParams.svelte.test.ts
+++ b/src/lib/utils/searchParams.svelte.test.ts
@@ -1,0 +1,246 @@
+import { flushSync, tick } from "svelte";
+import * as v from "valibot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { goto } from "$app/navigation";
+import * as appState from "$app/state";
+import searchParams from "./searchParams.svelte";
+
+// Mock the SvelteKit navigation boundary. `goto` is the observable effect of the
+// helper: mutating the reactive object should navigate to a new URL.
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+
+// Mock the reactive page URL. The factory owns a reactive box so that changing
+// the URL re-runs the helper's read effect, and exposes a setter for tests.
+vi.mock("$app/state", () => {
+  const box = $state({ current: new URL("http://localhost/") });
+  return {
+    page: {
+      get url() {
+        return box.current;
+      },
+    },
+    __setUrl: (url: URL) => {
+      box.current = url;
+    },
+  };
+});
+
+const setUrl = (search: string) => {
+  (appState as unknown as { __setUrl: (url: URL) => void }).__setUrl(
+    new URL(`http://localhost/${search}`),
+  );
+};
+
+const gotoMock = vi.mocked(goto);
+
+/** Drain the batched microtask flush and any effects the resulting nav triggers. */
+async function settle() {
+  for (let i = 0; i < 3; i++) {
+    flushSync();
+    await tick();
+  }
+}
+
+beforeEach(() => {
+  gotoMock.mockReset();
+  // Realistic round-trip: navigating updates the reactive URL.
+  gotoMock.mockImplementation((url) => {
+    setUrl((url as URL).search);
+    return Promise.resolve();
+  });
+});
+
+afterEach(() => {
+  setUrl("");
+});
+
+describe("searchParams", () => {
+  it("reads an existing single value from the URL", async () => {
+    setUrl("?q=nginx");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+
+    expect(params.q).toBe("nginx");
+
+    cleanup();
+  });
+
+  it("reads an existing array value from the URL", async () => {
+    setUrl("?category=Data&category=Web");
+    let params!: { category: string[] };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ category: v.optional(v.array(v.string()), []) });
+    });
+    await settle();
+
+    expect(params.category).toEqual(["Data", "Web"]);
+
+    cleanup();
+  });
+
+  it("applies schema defaults when a param is absent", async () => {
+    setUrl("");
+    let params!: { q: string; category: string[] };
+    const cleanup = $effect.root(() => {
+      params = searchParams({
+        q: v.optional(v.string(), "rock"),
+        category: v.optional(v.array(v.string()), []),
+      });
+    });
+    await settle();
+
+    expect(params.q).toBe("rock");
+    expect(params.category).toEqual([]);
+
+    cleanup();
+  });
+
+  it("does not navigate on initialization when values match the URL", async () => {
+    setUrl("?q=nginx");
+    const cleanup = $effect.root(() => {
+      searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+
+    expect(gotoMock).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("updates the URL when a string value is reassigned", async () => {
+    setUrl("");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.q = "django";
+    await settle();
+
+    expect(gotoMock).toHaveBeenCalledTimes(1);
+    expect((gotoMock.mock.calls[0][0] as URL).search).toBe("?q=django");
+
+    cleanup();
+  });
+
+  it("updates the URL when an array value is mutated", async () => {
+    setUrl("");
+    let params!: { category: string[] };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ category: v.optional(v.array(v.string()), []) });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.category.push("Data");
+    params.category.push("Web");
+    await settle();
+
+    expect(gotoMock).toHaveBeenCalledTimes(1);
+    expect((gotoMock.mock.calls[0][0] as URL).search).toBe(
+      "?category=Data&category=Web",
+    );
+
+    cleanup();
+  });
+
+  it("batches multiple synchronous mutations into a single navigation", async () => {
+    setUrl("");
+    let params!: { q: string; category: string[] };
+    const cleanup = $effect.root(() => {
+      params = searchParams({
+        q: v.optional(v.string(), ""),
+        category: v.optional(v.array(v.string()), []),
+      });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.q = "nginx";
+    params.category.push("Web");
+    await settle();
+
+    expect(gotoMock).toHaveBeenCalledTimes(1);
+    expect((gotoMock.mock.calls[0][0] as URL).search).toBe(
+      "?q=nginx&category=Web",
+    );
+
+    cleanup();
+  });
+
+  it("replaces history by default", async () => {
+    setUrl("");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.q = "django";
+    await settle();
+
+    expect(gotoMock.mock.calls[0][1]).toMatchObject({ replaceState: true });
+
+    cleanup();
+  });
+
+  it("pushes history when configured", async () => {
+    setUrl("");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams(
+        { q: v.optional(v.string(), "") },
+        { history: "push" },
+      );
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.q = "django";
+    await settle();
+
+    expect(gotoMock.mock.calls[0][1]).toMatchObject({ replaceState: false });
+
+    cleanup();
+  });
+
+  it("syncs the reactive object when the URL changes externally", async () => {
+    setUrl("?q=nginx");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+
+    setUrl("?q=django");
+    await settle();
+
+    expect(params.q).toBe("django");
+
+    cleanup();
+  });
+
+  it("does not navigate when a batch resolves back to the current URL", async () => {
+    setUrl("?q=nginx");
+    let params!: { q: string };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ q: v.optional(v.string(), "") });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.q = "django";
+    params.q = "nginx";
+    await settle();
+
+    expect(gotoMock).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});

--- a/src/lib/utils/searchParams.svelte.test.ts
+++ b/src/lib/utils/searchParams.svelte.test.ts
@@ -243,4 +243,21 @@ describe("searchParams", () => {
 
     cleanup();
   });
+
+  it("treats repeated-key value order as order-independent when checking URL equality", async () => {
+    setUrl("?q=nginx&category=Data&category=Web");
+    let params!: { category: string[] };
+    const cleanup = $effect.root(() => {
+      params = searchParams({ category: v.optional(v.array(v.string()), []) });
+    });
+    await settle();
+    gotoMock.mockClear();
+
+    params.category = ["Web", "Data"];
+    await settle();
+
+    expect(gotoMock).not.toHaveBeenCalled();
+
+    cleanup();
+  });
 });

--- a/src/lib/utils/searchParams.svelte.ts
+++ b/src/lib/utils/searchParams.svelte.ts
@@ -101,8 +101,7 @@ function buildSearchParams<T extends SchemaMap>(
 
 /** A stable, order-independent serialization used for equality checks. */
 function canonical(sp: URLSearchParams): string {
-  const clone = new URLSearchParams(sp);
-  clone.sort();
+  const clone = new URLSearchParams([...sp.entries()].sort());
   return clone.toString();
 }
 

--- a/src/lib/utils/searchParams.svelte.ts
+++ b/src/lib/utils/searchParams.svelte.ts
@@ -1,0 +1,169 @@
+import { untrack } from "svelte";
+import * as v from "valibot";
+import { goto } from "$app/navigation";
+import { page } from "$app/state";
+
+/** A map from query-parameter name to the valibot schema describing its value. */
+export type SchemaMap = Record<string, v.GenericSchema>;
+
+export type SearchParamsOptions = {
+  /**
+   * How URL updates affect browser history.
+   * - `"replace"` (default): update the URL in place, no new history entry.
+   * - `"push"`: add a new history entry per batched update.
+   */
+  history?: "replace" | "push";
+};
+
+/** The reactive object returned by {@link searchParams}, typed from the schemas. */
+export type SearchParams<T extends SchemaMap> = {
+  [K in keyof T]: v.InferOutput<T[K]>;
+};
+
+/** Unwrap wrapper schemas (optional/nullable/nullish/...) down to the core schema. */
+function unwrap(schema: v.GenericSchema): v.GenericSchema {
+  let current = schema;
+  while (current && typeof current === "object" && "wrapped" in current) {
+    current = (current as { wrapped: v.GenericSchema }).wrapped;
+  }
+  return current;
+}
+
+function isArraySchema(schema: v.GenericSchema): boolean {
+  return unwrap(schema).type === "array";
+}
+
+/** Read and validate a single key from the given search params. */
+function readKey(
+  schema: v.GenericSchema,
+  name: string,
+  sp: URLSearchParams,
+): unknown {
+  const raw = isArraySchema(schema)
+    ? sp.has(name)
+      ? sp.getAll(name)
+      : undefined
+    : sp.has(name)
+      ? sp.get(name)
+      : undefined;
+
+  const result = v.safeParse(schema, raw);
+  return result.success ? result.output : v.getDefault(schema);
+}
+
+/** Build the full reactive value object from the current URL search params. */
+function readAll<T extends SchemaMap>(
+  schemas: T,
+  sp: URLSearchParams,
+): SearchParams<T> {
+  const out = {} as SearchParams<T>;
+  for (const name in schemas) {
+    out[name] = readKey(
+      schemas[name],
+      name,
+      sp,
+    ) as SearchParams<T>[typeof name];
+  }
+  return out;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => item === b[index]);
+  }
+  return a === b;
+}
+
+/**
+ * Compose a new URLSearchParams from the current URL, overwriting only the keys
+ * we manage while preserving any unrelated params. Empty strings and empty
+ * arrays are dropped so absent params fall back to their schema defaults.
+ */
+function buildSearchParams<T extends SchemaMap>(
+  current: URLSearchParams,
+  schemas: T,
+  values: SearchParams<T>,
+): URLSearchParams {
+  const next = new URLSearchParams(current);
+  for (const name in schemas) {
+    next.delete(name);
+    const value = values[name];
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item !== "" && item != null) next.append(name, String(item));
+      }
+    } else if (value !== "" && value != null) {
+      next.set(name, String(value));
+    }
+  }
+  return next;
+}
+
+/** A stable, order-independent serialization used for equality checks. */
+function canonical(sp: URLSearchParams): string {
+  const clone = new URLSearchParams(sp);
+  clone.sort();
+  return clone.toString();
+}
+
+/**
+ * Reactive, batched helper for reading and writing URL search parameters.
+ *
+ * Pass a map of valibot schemas describing the expected shape. The returned
+ * object is reactive in both directions:
+ * - Reading reflects the current URL (validated/defaulted via the schemas).
+ * - Mutating a value (reassigning a string, or pushing/replacing an array)
+ *   updates the URL. Multiple synchronous mutations are batched into a single
+ *   navigation.
+ *
+ * Must be called during component initialization (or inside `$effect.root`),
+ * as it relies on `$effect`.
+ */
+function searchParams<T extends SchemaMap>(
+  schemas: T,
+  options: SearchParamsOptions = {},
+): SearchParams<T> {
+  const replaceState = options.history !== "push";
+  const values = $state(readAll(schemas, page.url.searchParams));
+
+  let flushScheduled = false;
+
+  function flush() {
+    flushScheduled = false;
+    const current = page.url.searchParams;
+    const next = buildSearchParams(current, schemas, values);
+    if (canonical(next) === canonical(current)) return;
+    const url = new URL(page.url);
+    url.search = next.toString();
+    goto(url, { replaceState, keepFocus: true, noScroll: true });
+  }
+
+  function scheduleFlush() {
+    if (flushScheduled) return;
+    flushScheduled = true;
+    queueMicrotask(flush);
+  }
+
+  // URL -> object: keep the reactive values in sync with the URL, only touching
+  // keys whose value actually changed to avoid clobbering and write loops.
+  $effect(() => {
+    const fresh = readAll(schemas, page.url.searchParams);
+    untrack(() => {
+      for (const name in schemas) {
+        if (!valuesEqual(values[name], fresh[name])) {
+          values[name] = fresh[name];
+        }
+      }
+    });
+  });
+
+  // object -> URL: deeply track every value and schedule a batched flush.
+  $effect(() => {
+    $state.snapshot(values);
+    scheduleFlush();
+  });
+
+  return values;
+}
+
+export default searchParams;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { expoOut } from "svelte/easing";
+  import { slide } from "svelte/transition";
+  import { navigating } from "$app/state";
   import favicon from "$lib/assets/favicon.png";
   import { SiteHeader } from "$lib/components/layout/SiteHeader";
   import "../app.css";
@@ -10,8 +13,34 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
+{#if navigating.complete !== null}
+  <!--
+    Loading animation for next page since svelte doesn't show any indicator.
+     - delay 100ms because most page loads are instant, and we don't want to flash
+     - long 10s duration because we don't actually know how long it will take
+     - exponential easing so fast loads (>100ms and <1s) still see enough progress,
+       while slow networks see it moving for a full 12 seconds
+  -->
+  <div
+    class="ds navigation-loader"
+    in:slide={{ delay: 100, duration: 10000, axis: "x", easing: expoOut }}
+  ></div>
+{/if}
+
 <SiteHeader />
 
 <main>
   {@render children()}
 </main>
+
+<style lang="css">
+  .ds.navigation-loader {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 100;
+    height: var(--dimension-050);
+    background-color: var(--color-brand-primary);
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
      - delay 100ms because most page loads are instant, and we don't want to flash
      - long 10s duration because we don't actually know how long it will take
      - exponential easing so fast loads (>100ms and <1s) still see enough progress,
-       while slow networks see it moving for a full 12 seconds
+       while slow networks see it moving for a full 10 seconds
   -->
   <div
     class="ds navigation-loader"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,6 +55,7 @@
 
             <!-- TODO: change this in some way to move the form logic into the SearchForm component -->
             <fieldset class="ds checkbox-group">
+                <legend class="visually-hidden">Categories</legend>
                 {#each CATEGORIES as category}
                     {@const lower = category.toLowerCase() }
                     <label class="ds checkbox-label" for="checkbox-{lower}">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,11 +25,11 @@
     category: optional(array(string()), []),
   });
 
+  const query = debounced(() => params.q, 200);
   const rocksRequest = $derived.by(() => {
-    const paramsDebounced = debounced(() => params, 200);
     return getRocks({
-      query: paramsDebounced().q,
-      categories: paramsDebounced().category,
+      query: query(),
+      categories: params.category,
     });
   });
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,21 +1,43 @@
 <script lang="ts">
-  import { queryParameters } from "sveltekit-search-params";
+  import { Checkbox } from "@canonical/svelte-ds-app-launchpad";
+  import { array, optional, string } from "valibot";
   import { RockList } from "$lib/components/rock/RockList";
   import { Heading } from "$lib/components/ui/Heading";
   import SearchForm from "$lib/components/ui/SearchForm/SearchForm.svelte";
   import { SmallCaps } from "$lib/components/ui/SmallCaps";
   import { getRocks } from "$lib/remote/api.remote";
   import debounced from "$lib/utils/debounced.svelte";
+  import searchParams from "$lib/utils/searchParams.svelte";
 
-  const params = queryParameters({ q: true });
-  const query = debounced(() => params.q, 200);
-  const rocksRequest = $derived(getRocks({ query: query() }));
+  const CATEGORIES = [
+    "Featured",
+    "Data",
+    "Identity",
+    "Networks",
+    "Observability",
+    "OS/Bases",
+    "Toolchains/Languages",
+    "Web",
+  ] as const;
+
+  const params = searchParams({
+    q: optional(string(), ""),
+    category: optional(array(string()), []),
+  });
+
+  const rocksRequest = $derived.by(() => {
+    const paramsDebounced = debounced(() => params, 200);
+    return getRocks({
+      query: paramsDebounced().q,
+      categories: paramsDebounced().category,
+    });
+  });
 </script>
 
 <svelte:head>
-    {#if query()}
+    {#if params.q}
         <title>
-            Search results for "{query()}" · Rock Store
+            Search results for "{params.q}" · Rock Store
         </title>
     {:else}
         <title>
@@ -31,7 +53,16 @@
         <aside style="grid-column: span 3">
             <Heading level={2}><SmallCaps>Categories</SmallCaps></Heading>
 
-            TODO...
+            <!-- TODO: change this in some way to move the form logic into the SearchForm component -->
+            <fieldset class="ds checkbox-group">
+                {#each CATEGORIES as category}
+                    {@const lower = category.toLowerCase() }
+                    <label class="ds checkbox-label" for="checkbox-{lower}">
+                        <Checkbox id="checkbox-{lower}" form="search-form" name="category" bind:group={params.category} value={category}/>
+                        {category}
+                    </label>
+                {/each}
+            </fieldset>
         </aside>
 
         <section style="grid-column: span 9">
@@ -45,5 +76,23 @@
 <style>
     .app-container {
         margin-block: var(--dimension-500);
+    }
+
+    .ds.checkbox-group {
+      --x-gap: var(--space-200);
+      --y-gap: var(--space-100);
+
+      padding: 0;
+      border: none;
+      display: grid;
+      row-gap: var(--y-gap);
+
+      label {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: var(--x-gap);
+        align-items: center;
+        cursor: pointer;
+      }
     }
 </style>


### PR DESCRIPTION
## Done
- refactored search parameters handling, replaced `sveltekit-search-params` with our own helpers
- added categories checkboxes and search via categories
- added search suggestions component
- added a loading indicator to show during navigation

## How to QA
- checkout this branch and `npm run dev` it
- open the Network tab in dev tools
- search by name
  - search parameter `q` in the URL should update in real time
  - the view updates after the API request is done
  - app shouldn't fire a request for each keystroke (unless you're typing slowly)
- click some checkboxes to search by category
  - search parameter `category` updates in real time
  - multiple categories are represented in the URL as `?category=<x>&category=<y>&...`
  - there are no rocks with categories at the moment so you'll see no results
- check loading indicator
  - enable network throttling in dev tools
  - navigate to some rock detail pages (try to focus and click quickly, otherwise sveltekit will load the page in the background)
  - at the top of the page you see an orange loading bar (when navigation takes longer than 100ms)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-37740

## Screenshots
