### PR TITLE
Improve test coverage

### DIFF
--- a/e2e/concurrency.test.ts
+++ b/e2e/concurrency.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+import { firstRockPath } from "./helpers";
+
+test("serves concurrent requests to the rock listing", async ({ request }) => {
+  const responses = await Promise.all(
+    Array.from({ length: 12 }, () => request.get("/")),
+  );
+
+  expect(responses.map((response) => response.status())).toEqual(
+    Array(12).fill(200),
+  );
+});
+
+test("serves concurrent requests to a detail page", async ({ request }) => {
+  const path = await firstRockPath(request);
+
+  const responses = await Promise.all(
+    Array.from({ length: 12 }, () => request.get(path)),
+  );
+
+  expect(responses.map((response) => response.status())).toEqual(
+    Array(12).fill(200),
+  );
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -9,7 +9,10 @@ import { expect } from "@playwright/test";
 let cached: Promise<string> | undefined;
 
 export function firstRockPath(request: APIRequestContext): Promise<string> {
-  cached ??= discoverFirstRockPath(request);
+  cached ??= discoverFirstRockPath(request).catch((err) => {
+    cached = undefined;
+    throw err;
+  });
   return cached;
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,37 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * These tests run against the real store API, so rock names are not known ahead
+ * of time. Rather than hardcode one that may be unpublished later, discover a
+ * real rock from the home page listing and drive the detail tests from that.
+ */
+let cached: Promise<string> | undefined;
+
+export function firstRockPath(request: APIRequestContext): Promise<string> {
+  cached ??= discoverFirstRockPath(request);
+  return cached;
+}
+
+async function discoverFirstRockPath(
+  request: APIRequestContext,
+): Promise<string> {
+  const response = await request.get("/");
+  expect(
+    response.ok(),
+    `home page request failed: ${response.status()} ${response.statusText()}`,
+  ).toBe(true);
+
+  const html = await response.text();
+  const match = html.match(
+    /<a[^>]*class="[^"]*\bname\b[^"]*"[^>]*href="([^"]+)"/,
+  );
+
+  if (!match) {
+    throw new Error(
+      "expected the home page to list at least one rock in its server-rendered HTML",
+    );
+  }
+
+  return match[1];
+}

--- a/e2e/home.test.ts
+++ b/e2e/home.test.ts
@@ -1,6 +1,54 @@
 import { expect, test } from "@playwright/test";
+import { firstRockPath } from "./helpers";
 
-test("home page renders the welcome heading", async ({ page }) => {
-  await page.goto("/");
-  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+test.describe("home page", () => {
+  test("renders the welcome heading", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeAttached();
+  });
+
+  test("lists rocks with links to their detail pages", async ({ page }) => {
+    await page.goto("/");
+
+    const cards = page.locator("a.name");
+
+    await expect(cards.first()).toBeVisible();
+    await expect(await cards.count()).toBeGreaterThan(0);
+  });
+
+  test("navigates to a rock from its card", async ({ page }) => {
+    await page.goto("/");
+
+    const card = page.locator("a.name").first();
+    const name = (await card.innerText()).trim();
+    await card.click();
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(name)));
+  });
+
+  // The search box drives a debounced remote query, so a result here means the
+  // page hydrated and the client-side round trip works.
+  test("filters results from the search box", async ({ page, request }) => {
+    const name = decodeURIComponent((await firstRockPath(request)).slice(1));
+
+    await page.goto("/");
+    await page.getByRole("searchbox", { name: "Search rocks" }).fill(name);
+
+    await expect(page).toHaveURL(/[?&]q=/);
+    await expect(
+      page.getByRole("heading", { name, level: 3, exact: true }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("home page without javascript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("server renders the rock list", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("a.name").first()).toBeVisible();
+  });
 });

--- a/e2e/rock-detail.test.ts
+++ b/e2e/rock-detail.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+import { firstRockPath } from "./helpers";
+
+test.describe("rock detail page", () => {
+  test("shows the rock name as the page heading", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  });
+
+  test("titles the document with the rock and the store", async ({
+    page,
+    request,
+  }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    await expect(page).toHaveTitle(/· Rock Store$/);
+  });
+
+  test("offers the description and tags tabs", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    const tabs = page.getByRole("navigation", { name: "Rock details" });
+
+    await expect(tabs.getByRole("link", { name: "Description" })).toBeVisible();
+    await expect(
+      tabs.getByRole("link", { name: "Tags and channels" }),
+    ).toBeVisible();
+  });
+
+  test("defaults to the description tab", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    const description = page
+      .getByRole("navigation", { name: "Rock details" })
+      .getByRole("link", { name: "Description" });
+
+    await expect(description).toHaveAttribute("aria-current", "page");
+  });
+
+  test("switches to the tags tab", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+    await page
+      .getByRole("navigation", { name: "Rock details" })
+      .getByRole("link", { name: "Tags and channels" })
+      .click();
+
+    await expect(page).toHaveURL(/tab=tags/);
+    await expect(
+      page
+        .getByRole("navigation", { name: "Rock details" })
+        .getByRole("link", { name: "Tags and channels" }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  test("shows the quick pull command", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    await expect(page.getByText("Quick pull")).toBeVisible();
+    await expect(page.locator("code").first()).toBeVisible();
+  });
+
+  test("links to the tags tab from the hero", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+    await page.getByRole("link", { name: "See all tags" }).click();
+
+    await expect(page).toHaveURL(/tab=tags/);
+  });
+
+  test("returns 404 for a rock that does not exist", async ({ page }) => {
+    const response = await page.goto("/definitely-not-a-real-rock-xyz-123");
+
+    expect(response?.status()).toBe(404);
+  });
+});
+
+test.describe("rock detail page without javascript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  // The store is server-rendered, so the detail page must be readable before
+  // (and without) hydration.
+  test("server renders the heading and tabs", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(path);
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "Rock details" }),
+    ).toBeVisible();
+    await expect(page.getByText("Quick pull")).toBeVisible();
+  });
+
+  test("server renders the tags tab", async ({ page, request }) => {
+    const path = await firstRockPath(request);
+
+    await page.goto(`${path}?tab=tags`);
+
+    await expect(
+      page
+        .getByRole("navigation", { name: "Rock details" })
+        .getByRole("link", { name: "Tags and channels" }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/src/lib/components/rock/RockDescription/RockDescription.svelte.test.ts
+++ b/src/lib/components/rock/RockDescription/RockDescription.svelte.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import { makeInfoRock } from "$lib/test-support/rock-fixtures";
+import RockDescription from "./RockDescription.svelte";
+
+describe("RockDescription.svelte", () => {
+  it("renders the summary", async () => {
+    render(RockDescription, {
+      rock: makeInfoRock({ metadata: { summary: "A tiny rock." } }),
+    });
+
+    await expect.element(page.getByText("A tiny rock.")).toBeVisible();
+  });
+
+  it("renders the description markdown as HTML", async () => {
+    render(RockDescription, {
+      rock: makeInfoRock({
+        metadata: { description: "## Usage\n\nRun it with **docker**." },
+      }),
+    });
+
+    await expect
+      .element(page.getByRole("heading", { name: "Usage", level: 2 }))
+      .toBeVisible();
+    await expect.element(page.getByText("docker")).toBeVisible();
+  });
+
+  it("does not emit raw HTML from the description", async () => {
+    const { container } = render(RockDescription, {
+      rock: makeInfoRock({
+        metadata: { description: "<script>alert('xss')</script>" },
+      }),
+    });
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("<script>");
+  });
+
+  it("shows the empty state when there is neither summary nor description", async () => {
+    render(RockDescription, { rock: makeInfoRock({ metadata: {} }) });
+
+    await expect
+      .element(page.getByText("No description provided."))
+      .toBeVisible();
+  });
+
+  it("shows the empty state when metadata is absent entirely", async () => {
+    render(RockDescription, { rock: makeInfoRock() });
+
+    await expect
+      .element(page.getByText("No description provided."))
+      .toBeVisible();
+  });
+
+  it("does not show the empty state when only a summary is present", async () => {
+    render(RockDescription, {
+      rock: makeInfoRock({ metadata: { summary: "A tiny rock." } }),
+    });
+
+    await expect
+      .element(page.getByText("No description provided."))
+      .not.toBeInTheDocument();
+  });
+
+  it("treats whitespace-only content as absent", async () => {
+    render(RockDescription, {
+      rock: makeInfoRock({
+        metadata: { summary: "   ", description: "  \n " },
+      }),
+    });
+
+    await expect
+      .element(page.getByText("No description provided."))
+      .toBeVisible();
+  });
+
+  it("renders both summary and description together", async () => {
+    render(RockDescription, {
+      rock: makeInfoRock({
+        metadata: { summary: "A tiny rock.", description: "# Details" },
+      }),
+    });
+
+    await expect.element(page.getByText("A tiny rock.")).toBeVisible();
+    await expect
+      .element(page.getByRole("heading", { name: "Details", level: 1 }))
+      .toBeVisible();
+  });
+});

--- a/src/lib/components/rock/RockFeedback/RockFeedback.svelte.test.ts
+++ b/src/lib/components/rock/RockFeedback/RockFeedback.svelte.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import RockFeedback from "./RockFeedback.svelte";
+
+describe("RockFeedback.svelte", () => {
+  it("labels the section", async () => {
+    render(RockFeedback, {});
+
+    await expect
+      .element(page.getByText("Feedback", { exact: true }))
+      .toBeVisible();
+  });
+
+  it("links to the survey in a new tab without leaking the opener", async () => {
+    const { container } = render(RockFeedback, {});
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      ".rock-feedback__text a",
+    );
+
+    expect(link?.textContent?.trim()).toBe("this short survey");
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+});

--- a/src/lib/components/rock/RockHero/RockHero.svelte.test.ts
+++ b/src/lib/components/rock/RockHero/RockHero.svelte.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import { makeChannel, makeInfoRock } from "$lib/test-support/rock-fixtures";
+import RockHero from "./RockHero.svelte";
+
+describe("RockHero.svelte", () => {
+  it("renders the rock title as the page heading", async () => {
+    render(RockHero, {
+      rock: makeInfoRock({ metadata: { title: "Redis" } }),
+    });
+
+    await expect
+      .element(page.getByRole("heading", { name: "Redis", level: 1 }))
+      .toBeVisible();
+  });
+
+  it("falls back to the rock name when there is no title", async () => {
+    render(RockHero, { rock: makeInfoRock({ name: "redis" }) });
+
+    await expect
+      .element(page.getByRole("heading", { name: "redis", level: 1 }))
+      .toBeVisible();
+  });
+
+  it("prefers the publisher display name over the username", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: {
+          publisher: { "display-name": "Canonical", username: "canonical-bot" },
+        },
+      }),
+    });
+
+    const meta = container.querySelector(".rock-hero__meta");
+
+    expect(meta?.textContent).toContain("Canonical");
+    expect(meta?.textContent).not.toContain("canonical-bot");
+  });
+
+  it("falls back to the publisher username", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: { publisher: { username: "canonical" } },
+      }),
+    });
+
+    expect(container.querySelector(".rock-hero__meta")?.textContent).toContain(
+      "canonical",
+    );
+  });
+
+  it("shows the first category", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: {
+          categories: [
+            { name: "databases", featured: false },
+            { name: "caching", featured: false },
+          ],
+        },
+      }),
+    });
+
+    const meta = container.querySelector(".rock-hero__meta");
+
+    expect(meta?.textContent).toContain("databases");
+    expect(meta?.textContent).not.toContain("caching");
+  });
+
+  it("separates publisher and category with a decorative dot", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: {
+          publisher: { username: "canonical" },
+          categories: [{ name: "databases", featured: false }],
+        },
+      }),
+    });
+
+    const dot = container.querySelector(
+      ".rock-hero__meta [aria-hidden='true']",
+    );
+
+    expect(dot?.textContent).toBe("·");
+  });
+
+  it("omits the separator when only one of publisher and category is present", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: { publisher: { username: "canonical" } },
+      }),
+    });
+
+    expect(
+      container.querySelector(".rock-hero__meta [aria-hidden='true']"),
+    ).toBeNull();
+  });
+
+  it("omits the meta line entirely without publisher or category", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    expect(container.querySelector(".rock-hero__meta")).toBeNull();
+  });
+
+  it("shows the most recent release date", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        "channel-map": [
+          makeChannel({ releasedAt: "2026-01-01T00:00:00Z" }),
+          makeChannel({ name: "1.0/edge", releasedAt: "2026-06-01T00:00:00Z" }),
+        ],
+      }),
+    });
+
+    const updated = container.querySelector(".rock-hero__updated");
+
+    expect(updated).not.toBeNull();
+    expect(updated?.querySelector("time")?.getAttribute("datetime")).toContain(
+      "2026-06-01",
+    );
+  });
+
+  it("falls back to the revision creation date", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        "channel-map": [
+          makeChannel({ releasedAt: null, createdAt: "2026-03-01T00:00:00Z" }),
+        ],
+      }),
+    });
+
+    expect(
+      container
+        .querySelector(".rock-hero__updated time")
+        ?.getAttribute("datetime"),
+    ).toContain("2026-03-01");
+  });
+
+  it("omits the updated line when no dates are available", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    expect(container.querySelector(".rock-hero__updated")).toBeNull();
+  });
+
+  it("shows the default track as the quick pull tag", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({ "default-track": "7.2" }),
+    });
+
+    expect(container.querySelector("code")?.textContent).toContain("7.2");
+  });
+
+  it("falls back to latest when there is no default track", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    expect(container.querySelector("code")?.textContent).toContain("latest");
+  });
+
+  it("links to the tags tab", async () => {
+    render(RockHero, { rock: makeInfoRock() });
+
+    const link = page.getByRole("link", { name: "See all tags" });
+
+    await expect.element(link).toHaveAttribute("href", "?tab=tags");
+  });
+
+  it("opens the docs link in a new tab without leaking the opener", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    const link =
+      container.querySelector<HTMLAnchorElement>(".rock-hero__learn");
+
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("uses the icon from metadata media", async () => {
+    const { container } = render(RockHero, {
+      rock: makeInfoRock({
+        metadata: {
+          media: [
+            {
+              type: "icon",
+              url: "https://example.com/i.png",
+              height: null,
+              width: null,
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.com/i.png",
+    );
+  });
+
+  it("falls back to the placeholder icon", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toContain(
+      "snapcraft-missing-icon.svg",
+    );
+  });
+
+  it("marks the icon as decorative", async () => {
+    const { container } = render(RockHero, { rock: makeInfoRock() });
+
+    expect(container.querySelector("img")?.getAttribute("alt")).toBe("");
+  });
+});

--- a/src/lib/components/rock/RockList/RockList.svelte.test.ts
+++ b/src/lib/components/rock/RockList/RockList.svelte.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import { makeFindItem } from "$lib/test-support/rock-fixtures";
+import RockList from "./RockList.svelte";
+
+describe("RockList.svelte", () => {
+  it("renders a card per rock", async () => {
+    render(RockList, {
+      rocks: [makeFindItem({ name: "redis" }), makeFindItem({ name: "nginx" })],
+    });
+
+    await expect
+      .element(page.getByRole("heading", { name: "redis", level: 3 }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("heading", { name: "nginx", level: 3 }))
+      .toBeVisible();
+  });
+
+  it("shows the empty state when there are no rocks", async () => {
+    const { container } = render(RockList, { rocks: [] });
+
+    expect(container.textContent).toContain("No results :(");
+    expect(container.querySelector("ul")).toBeNull();
+  });
+
+  it("gives the results a heading for screen readers", async () => {
+    render(RockList, { rocks: [makeFindItem()] });
+
+    await expect
+      .element(page.getByRole("heading", { name: "Search results", level: 2 }))
+      .toBeInTheDocument();
+  });
+
+  it("links each rock to its detail page", async () => {
+    const { container } = render(RockList, {
+      rocks: [makeFindItem({ name: "redis" })],
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>("a.name");
+
+    expect(link?.getAttribute("href")).toBe("/redis");
+  });
+
+  it("percent-encodes rock names in the detail link", async () => {
+    const { container } = render(RockList, {
+      rocks: [makeFindItem({ name: "my rock/1" })],
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>("a.name");
+
+    expect(link?.getAttribute("href")).toBe("/my%20rock%2F1");
+  });
+});
+
+describe("RockList.svelte rock card", () => {
+  it("shows the description from metadata", async () => {
+    render(RockList, {
+      rocks: [
+        makeFindItem({ metadata: { description: "An in-memory store" } }),
+      ],
+    });
+
+    await expect.element(page.getByText("An in-memory store")).toBeVisible();
+  });
+
+  it("falls back to a placeholder when there is no description", async () => {
+    render(RockList, { rocks: [makeFindItem()] });
+
+    await expect.element(page.getByText("No description")).toBeVisible();
+  });
+
+  it("shows the latest release version", async () => {
+    render(RockList, {
+      rocks: [
+        makeFindItem({
+          "default-release": {
+            revision: 3,
+            version: "7.2.1",
+            channel: {
+              name: "latest/stable",
+              risk: "stable",
+              track: "latest",
+              platform: { architecture: "amd64" },
+              "released-at": "2026-01-01T00:00:00Z",
+            },
+          },
+        }),
+      ],
+    });
+
+    await expect.element(page.getByText("Latest: 7.2.1")).toBeVisible();
+  });
+
+  it("falls back to a question mark when there is no release", async () => {
+    render(RockList, { rocks: [makeFindItem()] });
+
+    await expect.element(page.getByText("Latest: ?")).toBeVisible();
+  });
+
+  it("shows unknown when the release date is missing", async () => {
+    const { container } = render(RockList, { rocks: [makeFindItem()] });
+
+    expect(container.querySelector(".last-update")?.textContent).toContain(
+      "unknown",
+    );
+  });
+
+  it("renders category links pointing at the filtered home page", async () => {
+    const { container } = render(RockList, {
+      rocks: [
+        makeFindItem({
+          metadata: {
+            categories: [{ name: "databases", featured: false }],
+          },
+        }),
+      ],
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>(".categories a");
+
+    expect(link?.textContent?.trim()).toBe("databases");
+    expect(link?.getAttribute("href")).toBe("/?category=databases");
+  });
+
+  it("omits the categories block when there are none", async () => {
+    const { container } = render(RockList, { rocks: [makeFindItem()] });
+
+    expect(container.querySelector(".categories")).toBeNull();
+  });
+
+  it("uses the icon from metadata media", async () => {
+    const { container } = render(RockList, {
+      rocks: [
+        makeFindItem({
+          metadata: {
+            media: [
+              {
+                type: "icon",
+                url: "https://example.com/i.png",
+                height: null,
+                width: null,
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    expect(container.querySelector("img.logo")?.getAttribute("src")).toBe(
+      "https://example.com/i.png",
+    );
+  });
+
+  it("falls back to the placeholder icon when media has no icon", async () => {
+    const { container } = render(RockList, {
+      rocks: [
+        makeFindItem({
+          metadata: {
+            media: [
+              {
+                type: "screenshot",
+                url: "https://example.com/s.png",
+                height: null,
+                width: null,
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    expect(container.querySelector("img.logo")?.getAttribute("src")).toContain(
+      "snapcraft-missing-icon.svg",
+    );
+  });
+});

--- a/src/lib/components/rock/RockSidebar/RockSidebar.svelte
+++ b/src/lib/components/rock/RockSidebar/RockSidebar.svelte
@@ -27,7 +27,12 @@
     rockcraft: "rockcraft.yaml",
   };
 
-  type LinkRow = { icon: Component; label: string; href: string };
+  type LinkRow = {
+    key: string;
+    icon: Component;
+    label: string;
+    href: string;
+  };
 
   let { rock }: RockSidebarProps = $props();
 
@@ -85,6 +90,7 @@
       if (seen.has(url)) continue;
       seen.add(url);
       out.push({
+        key: url,
         icon: sourceIcon(key, url),
         label: SOURCE_LABELS[key] ?? displayUrl(url),
         href: hrefFor(url),
@@ -115,6 +121,7 @@
       seen.add(value);
       const email = isEmail(value);
       out.push({
+        key: value,
         icon: contactIcon(value, email),
         label: contactLabel(value, email),
         href: hrefFor(value),
@@ -138,7 +145,7 @@
       <dt><SmallCaps>Source code</SmallCaps></dt>
       <dd>
         <ul class="rock-sidebar__links">
-          {#each sourceCode as item (item.href)}{@render linkRow(item)}{/each}
+          {#each sourceCode as item (item.key)}{@render linkRow(item)}{/each}
         </ul>
       </dd>
     </div>
@@ -163,7 +170,7 @@
       <dt><SmallCaps>Contacts</SmallCaps></dt>
       <dd>
         <ul class="rock-sidebar__links">
-          {#each contacts as item (item.href)}{@render linkRow(item)}{/each}
+          {#each contacts as item (item.key)}{@render linkRow(item)}{/each}
         </ul>
       </dd>
     </div>

--- a/src/lib/components/rock/RockSidebar/RockSidebar.svelte.test.ts
+++ b/src/lib/components/rock/RockSidebar/RockSidebar.svelte.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import { makeChannel, makeInfoRock } from "$lib/test-support/rock-fixtures";
+import RockSidebar from "./RockSidebar.svelte";
+
+function linkRows(container: HTMLElement) {
+  return [
+    ...container.querySelectorAll<HTMLAnchorElement>(".rock-sidebar__row a"),
+  ];
+}
+
+describe("RockSidebar.svelte source code", () => {
+  it("labels a known source link key", async () => {
+    render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: ["https://github.com/canonical/x"] } },
+      }),
+    });
+
+    await expect.element(page.getByText("Rock source")).toBeVisible();
+  });
+
+  it("normalizes key casing, spaces, and underscores", async () => {
+    render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: {
+          links: { "Upstream Source": ["https://example.com/up"] },
+        },
+      }),
+    });
+
+    await expect.element(page.getByText("Upstream source")).toBeVisible();
+  });
+
+  it("deduplicates repeated urls across keys", async () => {
+    const url = "https://github.com/canonical/x";
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: [url], "source-code": [url] } },
+      }),
+    });
+
+    expect(linkRows(container).filter((a) => a.href === url)).toHaveLength(1);
+  });
+
+  it("skips empty url entries", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: ["", "https://example.com/x"] } },
+      }),
+    });
+
+    expect(linkRows(container)).toHaveLength(1);
+  });
+
+  it("ignores link keys it does not recognise", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { sponsorship: ["https://example.com/pay"] } },
+      }),
+    });
+
+    expect(container.textContent).not.toContain("Source code");
+  });
+
+  it("omits the section when there are no source links", async () => {
+    const { container } = render(RockSidebar, { rock: makeInfoRock() });
+
+    expect(container.textContent).not.toContain("Source code");
+  });
+
+  it("opens source links in a new tab without leaking the opener", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: ["https://example.com/x"] } },
+      }),
+    });
+
+    const link = linkRows(container)[0];
+
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+});
+
+describe("RockSidebar.svelte link safety", () => {
+  it("neutralises a javascript: url", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: ["javascript:alert(1)"] } },
+      }),
+    });
+
+    expect(linkRows(container)[0].getAttribute("href")).toBe("#");
+  });
+
+  it("neutralises a protocol-relative url", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { links: { source: ["//evil.example.com"] } },
+      }),
+    });
+
+    expect(linkRows(container)[0].getAttribute("href")).toBe("#");
+  });
+
+  it("renders two blocked source urls without colliding", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: {
+          links: { source: ["javascript:alert(1)", "data:text/html,x"] },
+        },
+      }),
+    });
+
+    const hrefs = linkRows(container).map((a) => a.getAttribute("href"));
+
+    expect(hrefs).toEqual(["#", "#"]);
+  });
+
+  it("renders two blocked contact urls without colliding", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: {
+          contact: "javascript:alert(1)",
+          links: { contact: ["data:text/html,x"] },
+        },
+      }),
+    });
+
+    expect(linkRows(container)).toHaveLength(2);
+  });
+
+  it("keeps http, https, and mailto urls intact", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: {
+          links: {
+            source: ["https://example.com/a"],
+            upstream: ["http://example.com/b"],
+          },
+          contact: "mailto:team@example.com",
+        },
+      }),
+    });
+
+    const hrefs = linkRows(container).map((a) => a.getAttribute("href"));
+
+    expect(hrefs).toContain("https://example.com/a");
+    expect(hrefs).toContain("http://example.com/b");
+    expect(hrefs).toContain("mailto:team@example.com");
+  });
+});
+
+describe("RockSidebar.svelte architectures", () => {
+  it("lists architectures uppercased and comma separated", async () => {
+    render(RockSidebar, {
+      rock: makeInfoRock({
+        "channel-map": [
+          makeChannel({ architecture: "amd64" }),
+          makeChannel({ name: "1.0/edge", architecture: "arm64" }),
+        ],
+      }),
+    });
+
+    await expect.element(page.getByText("AMD64, ARM64")).toBeVisible();
+  });
+
+  it("omits the section when there are no architectures", async () => {
+    const { container } = render(RockSidebar, { rock: makeInfoRock() });
+
+    expect(container.textContent).not.toContain("Architectures");
+  });
+});
+
+describe("RockSidebar.svelte license", () => {
+  it("shows a trimmed license", async () => {
+    render(RockSidebar, {
+      rock: makeInfoRock({ metadata: { license: "  Apache-2.0  " } }),
+    });
+
+    await expect.element(page.getByText("Apache-2.0")).toBeVisible();
+  });
+
+  it("omits the section for a whitespace-only license", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({ metadata: { license: "   " } }),
+    });
+
+    expect(container.textContent).not.toContain("License");
+  });
+});
+
+describe("RockSidebar.svelte contacts", () => {
+  it("turns a bare email into a mailto link labelled with the address", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({ metadata: { contact: "team@example.com" } }),
+    });
+
+    const link = linkRows(container)[0];
+
+    expect(link.getAttribute("href")).toBe("mailto:team@example.com");
+    expect(link.textContent?.trim()).toBe("team@example.com");
+  });
+
+  it("strips the mailto prefix from the label", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({ metadata: { contact: "mailto:team@example.com" } }),
+    });
+
+    expect(linkRows(container)[0].textContent?.trim()).toBe("team@example.com");
+  });
+
+  it("labels a url contact with its last path segment", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: { contact: "https://github.com/canonical/rocks/issues" },
+      }),
+    });
+
+    expect(linkRows(container)[0].textContent?.trim()).toBe("issues");
+  });
+
+  it("merges the contact field with contact links, deduplicated", async () => {
+    const { container } = render(RockSidebar, {
+      rock: makeInfoRock({
+        metadata: {
+          contact: "team@example.com",
+          links: { contact: ["team@example.com", "other@example.com"] },
+        },
+      }),
+    });
+
+    expect(linkRows(container)).toHaveLength(2);
+  });
+
+  it("omits the section when there are no contacts", async () => {
+    const { container } = render(RockSidebar, { rock: makeInfoRock() });
+
+    expect(container.textContent).not.toContain("Contacts");
+  });
+});
+
+describe("RockSidebar.svelte discourse", () => {
+  it("always offers the discussion link", async () => {
+    render(RockSidebar, { rock: makeInfoRock() });
+
+    await expect
+      .element(page.getByRole("link", { name: "Join the discussion" }))
+      .toBeVisible();
+  });
+});

--- a/src/lib/components/ssr-rendering.spec.ts
+++ b/src/lib/components/ssr-rendering.spec.ts
@@ -1,0 +1,183 @@
+import { render } from "svelte/server";
+import { describe, expect, it } from "vitest";
+import RockDescription from "$lib/components/rock/RockDescription/RockDescription.svelte";
+import RockFeedback from "$lib/components/rock/RockFeedback/RockFeedback.svelte";
+import RockHero from "$lib/components/rock/RockHero/RockHero.svelte";
+import RockList from "$lib/components/rock/RockList/RockList.svelte";
+import RockSidebar from "$lib/components/rock/RockSidebar/RockSidebar.svelte";
+import ImageWithFallback from "$lib/components/ui/ImageWithFallback/ImageWithFallback.svelte";
+import Tabs from "$lib/components/ui/Tabs/Tabs.svelte";
+import {
+  makeChannel,
+  makeFindItem,
+  makeInfoRock,
+} from "$lib/test-support/rock-fixtures";
+
+const ROCK = makeInfoRock({
+  name: "redis",
+  "default-track": "7.2",
+  "channel-map": [makeChannel({ architecture: "amd64" })],
+  metadata: {
+    title: "Redis",
+    summary: "An in-memory data store.",
+    description: "## Usage\n\nRun it with **docker**.",
+    license: "Apache-2.0",
+    publisher: { "display-name": "Canonical" },
+    links: { source: ["https://github.com/canonical/redis-rock"] },
+    contact: "team@example.com",
+  },
+});
+
+describe("RockHero server rendering", () => {
+  it("emits the title, publisher, and quick pull tag", () => {
+    const { body } = render(RockHero, { props: { rock: ROCK } });
+
+    expect(body).toContain("Redis");
+    expect(body).toContain("Canonical");
+    expect(body).toContain("7.2");
+  });
+
+  it("emits an h1 so the page has a heading before hydration", () => {
+    const { body } = render(RockHero, { props: { rock: ROCK } });
+
+    expect(body).toMatch(/<h1[^>]*>/);
+  });
+
+  it("renders a rock with no metadata at all", () => {
+    const { body } = render(RockHero, {
+      props: { rock: makeInfoRock({ name: "bare" }) },
+    });
+
+    expect(body).toContain("bare");
+  });
+});
+
+describe("RockDescription server rendering", () => {
+  it("emits the summary and the rendered markdown", () => {
+    const { body } = render(RockDescription, { props: { rock: ROCK } });
+
+    expect(body).toContain("An in-memory data store.");
+    expect(body).toContain("<h2>Usage</h2>");
+    expect(body).toContain("<strong>docker</strong>");
+  });
+
+  it("escapes raw HTML from the description", () => {
+    const { body } = render(RockDescription, {
+      props: {
+        rock: makeInfoRock({
+          metadata: { description: "<script>alert('xss')</script>" },
+        }),
+      },
+    });
+
+    expect(body).not.toContain("<script>");
+    expect(body).toContain("&lt;script&gt;");
+  });
+
+  it("emits the empty state when there is no content", () => {
+    const { body } = render(RockDescription, {
+      props: { rock: makeInfoRock() },
+    });
+
+    expect(body).toContain("No description provided.");
+  });
+});
+
+describe("RockSidebar server rendering", () => {
+  it("emits source links, architectures, license, and contacts", () => {
+    const { body } = render(RockSidebar, { props: { rock: ROCK } });
+
+    expect(body).toContain("https://github.com/canonical/redis-rock");
+    expect(body).toContain("AMD64");
+    expect(body).toContain("Apache-2.0");
+    expect(body).toContain("mailto:team@example.com");
+  });
+
+  it("neutralises blocked url schemes server-side too", () => {
+    const { body } = render(RockSidebar, {
+      props: {
+        rock: makeInfoRock({
+          metadata: { links: { source: ["javascript:alert(1)"] } },
+        }),
+      },
+    });
+
+    expect(body).not.toContain("javascript:alert");
+  });
+
+  it("renders two blocked urls without a key collision", () => {
+    const { body } = render(RockSidebar, {
+      props: {
+        rock: makeInfoRock({
+          metadata: {
+            links: { source: ["javascript:alert(1)", "data:text/html,x"] },
+          },
+        }),
+      },
+    });
+
+    expect(body).toContain("Source code");
+  });
+});
+
+describe("RockList server rendering", () => {
+  it("emits a linked card per rock", () => {
+    const { body } = render(RockList, {
+      props: {
+        rocks: [
+          makeFindItem({ name: "redis" }),
+          makeFindItem({ name: "nginx" }),
+        ],
+      },
+    });
+
+    expect(body).toContain('href="/redis"');
+    expect(body).toContain('href="/nginx"');
+  });
+
+  it("emits the empty state with no rocks", () => {
+    const { body } = render(RockList, { props: { rocks: [] } });
+
+    expect(body).toContain("No results :(");
+  });
+});
+
+describe("Tabs server rendering", () => {
+  it("marks the active tab before hydration", () => {
+    const { body } = render(Tabs, {
+      props: {
+        tabs: [
+          { id: "description", label: "Description", href: "?tab=description" },
+          { id: "tags", label: "Tags", href: "?tab=tags" },
+        ],
+        active: "tags",
+      },
+    });
+
+    expect(body).toContain('aria-current="page"');
+    expect(body).toContain("Description");
+    expect(body).toContain("Tags");
+  });
+});
+
+describe("ImageWithFallback server rendering", () => {
+  it("emits the original src", () => {
+    const { body } = render(ImageWithFallback, {
+      props: {
+        src: "https://example.com/i.png",
+        fallback: "https://example.com/fallback.png",
+        alt: "",
+      },
+    });
+
+    expect(body).toContain('src="https://example.com/i.png"');
+  });
+});
+
+describe("RockFeedback server rendering", () => {
+  it("emits the survey link", () => {
+    const { body } = render(RockFeedback, { props: {} });
+
+    expect(body).toContain("this short survey");
+  });
+});

--- a/src/lib/components/ui/ImageWithFallback/ImageWithFallback.svelte.test.ts
+++ b/src/lib/components/ui/ImageWithFallback/ImageWithFallback.svelte.test.ts
@@ -62,9 +62,7 @@ describe("ImageWithFallback.svelte", () => {
     });
 
     await vi.waitFor(() => expect(onerror).toHaveBeenCalledTimes(2));
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(onerror).toHaveBeenCalledTimes(2);
     expect(imageIn(container).getAttribute("src")).toBe(ALSO_BROKEN);
   });
 

--- a/src/lib/components/ui/ImageWithFallback/ImageWithFallback.svelte.test.ts
+++ b/src/lib/components/ui/ImageWithFallback/ImageWithFallback.svelte.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import ImageWithFallback from "./ImageWithFallback.svelte";
+
+const VALID =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+const BROKEN = "data:image/gif;base64,!!!not-an-image";
+const ALSO_BROKEN = "data:image/gif;base64,!!!also-not-an-image";
+
+function imageIn(container: HTMLElement): HTMLImageElement {
+  const img = container.querySelector("img");
+  if (!img) throw new Error("no img rendered");
+  return img;
+}
+
+describe("ImageWithFallback.svelte", () => {
+  it("renders the given source and alt text", async () => {
+    const { container } = render(ImageWithFallback, {
+      src: VALID,
+      fallback: VALID,
+      alt: "a rock",
+    });
+
+    const img = imageIn(container);
+
+    expect(img.getAttribute("src")).toBe(VALID);
+    expect(img.getAttribute("alt")).toBe("a rock");
+  });
+
+  it("swaps to the fallback when the source fails to load", async () => {
+    const { container } = render(ImageWithFallback, {
+      src: BROKEN,
+      fallback: VALID,
+      alt: "a rock",
+    });
+
+    await vi.waitFor(() =>
+      expect(imageIn(container).getAttribute("src")).toBe(VALID),
+    );
+  });
+
+  it("forwards the caller's onerror handler", async () => {
+    const onerror = vi.fn();
+    render(ImageWithFallback, {
+      src: BROKEN,
+      fallback: VALID,
+      alt: "a rock",
+      onerror,
+    });
+
+    await vi.waitFor(() => expect(onerror).toHaveBeenCalled());
+  });
+
+  it("stops at the fallback when the fallback also fails", async () => {
+    const onerror = vi.fn();
+    const { container } = render(ImageWithFallback, {
+      src: BROKEN,
+      fallback: ALSO_BROKEN,
+      alt: "a rock",
+      onerror,
+    });
+
+    await vi.waitFor(() => expect(onerror).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(onerror).toHaveBeenCalledTimes(2);
+    expect(imageIn(container).getAttribute("src")).toBe(ALSO_BROKEN);
+  });
+
+  it("returns to the new source when the src prop changes after a fallback", async () => {
+    const { container, rerender } = render(ImageWithFallback, {
+      src: BROKEN,
+      fallback: VALID,
+      alt: "a rock",
+    });
+
+    await vi.waitFor(() =>
+      expect(imageIn(container).getAttribute("src")).toBe(VALID),
+    );
+
+    await rerender({ src: ALSO_BROKEN, fallback: VALID, alt: "a rock" });
+
+    expect(imageIn(container).getAttribute("src")).toBe(ALSO_BROKEN);
+  });
+
+  it("passes through additional attributes", async () => {
+    const { container } = render(ImageWithFallback, {
+      src: VALID,
+      fallback: VALID,
+      alt: "a rock",
+      title: "Rock logo",
+    });
+
+    expect(imageIn(container).getAttribute("title")).toBe("Rock logo");
+  });
+});

--- a/src/lib/components/ui/Tabs/Tabs.svelte.test.ts
+++ b/src/lib/components/ui/Tabs/Tabs.svelte.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import Tabs from "./Tabs.svelte";
+import type { TabItem } from "./types.js";
+
+const TABS: TabItem[] = [
+  { id: "overview", label: "Overview", href: "?tab=overview" },
+  { id: "tags", label: "Tags", href: "?tab=tags" },
+];
+
+describe("Tabs.svelte", () => {
+  it("renders a link per tab", async () => {
+    render(Tabs, { tabs: TABS, active: "overview" });
+
+    await expect
+      .element(page.getByRole("link", { name: "Overview" }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("link", { name: "Tags" }))
+      .toBeVisible();
+  });
+
+  it("points each tab at its href", async () => {
+    const { container } = render(Tabs, { tabs: TABS, active: "overview" });
+
+    const hrefs = [...container.querySelectorAll("a")].map((a) =>
+      a.getAttribute("href"),
+    );
+
+    expect(hrefs).toEqual(["?tab=overview", "?tab=tags"]);
+  });
+
+  it("marks only the active tab as the current page", async () => {
+    const { container } = render(Tabs, { tabs: TABS, active: "tags" });
+
+    const current = [...container.querySelectorAll("a")].filter(
+      (a) => a.getAttribute("aria-current") === "page",
+    );
+
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent?.trim()).toBe("Tags");
+  });
+
+  it("marks nothing current when active matches no tab", async () => {
+    const { container } = render(Tabs, { tabs: TABS, active: "nope" });
+
+    expect(container.querySelector("[aria-current]")).toBeNull();
+  });
+
+  it("labels the navigation landmark by default", async () => {
+    render(Tabs, { tabs: TABS, active: "overview" });
+
+    await expect
+      .element(page.getByRole("navigation", { name: "Tabs" }))
+      .toBeVisible();
+  });
+
+  it("allows overriding the navigation label", async () => {
+    render(Tabs, {
+      tabs: TABS,
+      active: "overview",
+      "aria-label": "Rock sections",
+    });
+
+    await expect
+      .element(page.getByRole("navigation", { name: "Rock sections" }))
+      .toBeVisible();
+  });
+
+  it("opts tab links out of scroll restoration", async () => {
+    const { container } = render(Tabs, { tabs: TABS, active: "overview" });
+
+    for (const link of container.querySelectorAll("a")) {
+      expect(link.hasAttribute("data-sveltekit-noscroll")).toBe(true);
+    }
+  });
+
+  it("renders no links when there are no tabs", async () => {
+    const { container } = render(Tabs, { tabs: [], active: "overview" });
+
+    expect(container.querySelectorAll("a")).toHaveLength(0);
+  });
+});

--- a/src/lib/remote/api.remote.ts
+++ b/src/lib/remote/api.remote.ts
@@ -1,17 +1,26 @@
-import { getAbortSignal } from "svelte";
-import { query } from "$app/server";
+import { getRequestEvent, query } from "$app/server";
 import {
   ApiClient,
   getRockDetailsSchema,
   getRocksSchema,
 } from "../server/api/rocks";
 
+/**
+ * Not Svelte's `getAbortSignal()`: `ApiClient` resolves the signal lazily at
+ * fetch time, by which point that reaction is often already destroyed, so
+ * concurrent requests throw `StaleReactionError` and 500. This one lives as
+ * long as the request and still cancels the upstream fetch.
+ */
+function requestSignal(): AbortSignal {
+  return getRequestEvent().request.signal;
+}
+
 export const getRocks = query(getRocksSchema, async (input) => {
-  const client = new ApiClient(getAbortSignal);
+  const client = new ApiClient(requestSignal);
   return await client.getRocks(input);
 });
 
 export const getRockDetails = query(getRockDetailsSchema, async (input) => {
-  const client = new ApiClient(getAbortSignal);
+  const client = new ApiClient(requestSignal);
   return await client.getRockDetails(input);
 });

--- a/src/lib/test-support/rock-fixtures.ts
+++ b/src/lib/test-support/rock-fixtures.ts
@@ -1,0 +1,55 @@
+import type {
+  ChannelMapItem,
+  Metadata,
+  RockFindResultItem,
+  RockInfoResponse,
+} from "$lib/server/api/types";
+
+export function makeInfoRock(
+  overrides: Partial<RockInfoResponse> = {},
+): RockInfoResponse {
+  return {
+    name: "test-rock",
+    "package-id": "pkg-1",
+    ...overrides,
+  };
+}
+
+export function makeFindItem(
+  overrides: Partial<RockFindResultItem> = {},
+): RockFindResultItem {
+  return {
+    name: "test-rock",
+    "package-id": "pkg-1",
+    ...overrides,
+  };
+}
+
+export function makeMetadata(overrides: Partial<Metadata> = {}): Metadata {
+  return { ...overrides };
+}
+
+export function makeChannel({
+  name = "1.0/stable",
+  version = "1.0.0",
+  architecture = "amd64",
+  releasedAt = "2026-01-01T00:00:00Z",
+  createdAt,
+}: {
+  name?: string;
+  version?: string;
+  architecture?: string;
+  releasedAt?: string | null;
+  createdAt?: string;
+} = {}): ChannelMapItem {
+  return {
+    channel: {
+      name,
+      risk: name.split("/")[1] ?? "stable",
+      track: name.split("/")[0],
+      platform: { architecture },
+      "released-at": releasedAt,
+    },
+    revision: { version, ...(createdAt ? { "created-at": createdAt } : {}) },
+  };
+}

--- a/src/lib/utils/markdown.spec.ts
+++ b/src/lib/utils/markdown.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown";
+
+describe("renderMarkdown", () => {
+  it("renders ordinary markdown", () => {
+    const html = renderMarkdown("# Title\n\nSome **bold** text.");
+
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<strong>bold</strong>");
+  });
+
+  it("escapes raw HTML instead of emitting it", () => {
+    const html = renderMarkdown("<script>alert('xss')</script>");
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("escapes inline HTML attributes that could carry handlers", () => {
+    const html = renderMarkdown('<img src="x" onerror="alert(1)">');
+
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("escapes HTML inside fenced code blocks", () => {
+    const html = renderMarkdown("```\n<script>alert(1)</script>\n```");
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("does not build an anchor for a javascript: link", () => {
+    const html = renderMarkdown("[click me](javascript:alert(1))");
+
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("click me");
+  });
+
+  it("does not build an anchor for a vbscript: link", () => {
+    const html = renderMarkdown("[click me](vbscript:msgbox(1))");
+
+    expect(html).not.toContain("<a ");
+  });
+
+  it("does not build an anchor for a non-image data: link", () => {
+    const html = renderMarkdown(
+      "[click me](data:text/html,<script>1</script>)",
+    );
+
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("allows image data: URIs", () => {
+    const html = renderMarkdown(
+      "![dot](data:image/gif;base64,R0lGODlhAQABAAAAACw=)",
+    );
+
+    expect(html).toContain("data:image/gif;base64");
+  });
+
+  it("keeps ordinary http and https links", () => {
+    const html = renderMarkdown("[canonical](https://canonical.com)");
+
+    expect(html).toContain('href="https://canonical.com"');
+  });
+
+  it("linkifies bare URLs", () => {
+    const html = renderMarkdown("See https://canonical.com for details.");
+
+    expect(html).toContain('<a href="https://canonical.com"');
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(renderMarkdown("")).toBe("");
+  });
+});

--- a/src/routes/[rock]/page.server.spec.ts
+++ b/src/routes/[rock]/page.server.spec.ts
@@ -1,0 +1,59 @@
+import { isHttpError } from "@sveltejs/kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  StoreApiConnectionError,
+  StoreApiResourceNotFound,
+} from "$lib/server/api/errors";
+import { load } from "./+page.server";
+
+const { getRockDetails } = vi.hoisted(() => ({ getRockDetails: vi.fn() }));
+
+vi.mock("$lib/server/api/rocks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("$lib/server/api/rocks")>()),
+  ApiClient: class {
+    getRockDetails = getRockDetails;
+  },
+}));
+
+async function loadWith(name: string) {
+  return await load({ params: { rock: name } } as Parameters<typeof load>[0]);
+}
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("[rock] page load", () => {
+  it("returns the rock from the api client", async () => {
+    const rock = { name: "redis", "package-id": "pkg-1" };
+    getRockDetails.mockResolvedValue(rock);
+
+    await expect(loadWith("redis")).resolves.toEqual({ rock });
+  });
+
+  it("looks the rock up by the route parameter", async () => {
+    getRockDetails.mockResolvedValue({ name: "redis" });
+
+    await loadWith("redis");
+
+    expect(getRockDetails).toHaveBeenCalledWith({ name: "redis" });
+  });
+
+  it("turns a missing rock into a 404 naming the rock", async () => {
+    getRockDetails.mockRejectedValue(new StoreApiResourceNotFound("nope"));
+
+    const err = await loadWith("ghost").catch((e: unknown) => e);
+
+    if (!isHttpError(err)) throw new Error(`expected an HttpError, got ${err}`);
+
+    expect(err.status).toBe(404);
+    expect(err.body.message).toBe('Rock "ghost" not found');
+  });
+
+  it("rethrows other api errors untouched", async () => {
+    const failure = new StoreApiConnectionError("upstream down");
+    getRockDetails.mockRejectedValue(failure);
+
+    await expect(loadWith("redis")).rejects.toBe(failure);
+  });
+});


### PR DESCRIPTION
## Done
- add more tests
- RockSidebar crashed when a rock had two blocked URLs both became href="#", and the each was keyed on
  href, so duplicate keys threw.
- The home page 500'd under concurrent load getAbortSignal was resolved too late, after its reaction was
  destroyed, throwing StaleReactionError.

## How to QA
verify the tests are passed

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-37349

