### PR TITLE
Add Pragma design-system guardrails (docs pointer + --lp- CI check)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Check linting and formatting
         run: npm run check
 
+      - name: Check no authored --lp- tokens
+        run: npm run check:tokens
+
   typecheck:
     name: Type check (svelte-check)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Check no authored --lp- tokens
         run: npm run check:tokens
 
+      - name: Check component styles are in styles.css
+        run: npm run check:styles
+
   typecheck:
     name: Type check (svelte-check)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ in `docs` and the relevant source files and tests.
 Read documentation files lazily - only those you need for the task at hand - when you need to understand a given part of the application
 (along with reading any code files for more specific details).
 
+Any UI or styling work: read [`docs/pragma-design-system.md`](docs/pragma-design-system.md) first — it defines the component and token rules (notably: never author `--lp-*` tokens in our own styles). The `check:tokens` script enforces that rule.
+
 ## Workflow
 
 ### Small changes

--- a/docs/pragma-design-system.md
+++ b/docs/pragma-design-system.md
@@ -25,6 +25,14 @@ When step 3 fires (a value with no generic token), we add a project token rather
 
 For example, `--app-content-max-width` (`72rem`) exists because Pragma has no container-width token.
 
+## Component style conventions
+
+Applies to reusable components under `src/lib/components` — not route `+page.svelte` / `+layout.svelte` files, which may keep small page-scoped `<style>` blocks.
+
+- **Styles live in a co-located `styles.css`**, imported by the component — not in a Svelte `<style>` block. Enforced in CI by the `check:styles` script.
+- **The root element carries `ds <name>`** (e.g. `class="ds tabs"`), and the stylesheet scopes every rule under `.ds.<name>` (e.g. `.ds.tabs { … }`). This namespaces our styles and mirrors how Pragma's own components are structured.
+- A style-less passthrough component (one that just forwards an element, e.g. `ImageWithFallback` around an `<img>`) needs neither.
+
 ## The two token systems
 
 Pragma exposes two **non-interchangeable** token vocabularies:

--- a/docs/pragma-design-system.md
+++ b/docs/pragma-design-system.md
@@ -1,0 +1,52 @@
+# Pragma design system in rocks-storefront
+
+This app is a **POC for adopting Canonical's [Pragma](https://github.com/canonical/pragma) design system** in SvelteKit.
+
+## Build policy (follow this order)
+
+When building any UI, go down this list and stop at the first that applies:
+
+1. **Use a Pragma component if one exists.** Reuse `@canonical/svelte-ds-app-launchpad` components as much as possible (they're the only ready-made Pragma Svelte components). Wrap them in thin local components so they're easy to swap later.
+2. **No component → build our own, styled with GENERIC Pragma tokens** from `@canonical/styles` (`--color-*`, `--space-*`, `--dimension-*`, `--typography-*`).
+3. **No suitable generic token → STOP and flag it.** Do not hardcode a value and do not reach for a launchpad token. Raise it so we add a **project-defined token** (see below).
+4. **Never author `--lp-*` (launchpad) tokens in our own styles.** Enforced in CI by the `check:tokens` script.
+
+### The one nuance
+
+The launchpad *components* we reuse in step 1 are themselves built on `--lp-*` internally, so using them still puts `--lp-*` *values* into the rendered UI. That's fine — the rule is about **what we author**: our own CSS never references `--lp-*`. (Trade-off: launchpad components and our generic-token components may not visually match until launchpad components are replaced.)
+
+### Project-defined tokens
+
+When step 3 fires (a value with no generic token), we add a project token rather than a literal or an `--lp-*` token:
+
+- Name it in the **generic style** (e.g. `--app-content-max-width`), not `--lp-*`.
+- Define it once in `:root` in [`src/app.css`](../src/app.css).
+- **Flag it to the team and get approval before adding it** (no silent magic numbers).
+
+For example, `--app-content-max-width` (`72rem`) exists because Pragma has no container-width token.
+
+## The two token systems
+
+Pragma exposes two **non-interchangeable** token vocabularies:
+
+| | Package | Prefix | We author with it? |
+| --- | --- | --- | --- |
+| **Generic (upstream)** | `@canonical/design-tokens` via `@canonical/styles` | `--color-*`, `--space-*`, `--dimension-*`, `--typography-*` | **Yes — always** |
+| **Launchpad (app-specific)** | `@canonical/launchpad-design-tokens` | `--lp-*` | **No** (only reached indirectly, inside launchpad components) |
+
+They're disconnected: `--lp-*` tokens are their own raw literals and reference the generic set 0 times. Generic colours theme automatically via native `light-dark()`. Generic typography has no `font:` shorthand — it's decomposed into sub-tokens, so heading/body rules set the five individually (`-font-family`, `-font-size`, `-font-weight`, `-letter-spacing`, `-line-height`), e.g. `--typography-heading-1-font-size`.
+
+## Why launchpad components at all
+
+There is **no global Svelte component package** in Pragma yet (`react-ds-global` exists; `svelte-ds-global` does not). The only ready-made Pragma Svelte components are the app-specific ones, and `@canonical/svelte-ds-app-launchpad` is the most complete — so it's our component source until we build our own / upstream ships a Svelte global tier.
+
+## How it's wired
+
+Imported once in [`src/app.css`](../src/app.css):
+
+- `@canonical/styles` — generic tokens + typography (**what we author with**)
+- `@canonical/svelte-ds-app-launchpad/styles.css` + `@canonical/launchpad-design-tokens/...` — needed so the launchpad components we reuse render correctly
+
+## Migration endpoint
+
+All our authored styles on generic tokens; all components either Pragma components or our own. Launchpad components + `--lp-*` are a bridge removed as each piece is replaced. Brand values, when needed, come from a **theme/mode** overriding the generic semantic tokens (like `@canonical/styles-modes-canonical`) — never a new `--lp-*`-style island.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "svelte-kit sync; husky",
     "svelte-check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "svelte-check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "check:tokens": "! grep -rIn --include='*.svelte' --include='*.css' -- '--lp-' src/",
+    "check:tokens": "grep -rIn --include='*.svelte' --include='*.css' -- '--lp-' src/ && { echo 'Found authored --lp- token(s) in src/. Use generic Pragma tokens instead.' >&2; exit 1; } || test $? -eq 1",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check .",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "svelte-check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "svelte-check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "check:tokens": "grep -rIn --include='*.svelte' --include='*.css' -- '--lp-' src/ && { echo 'Found authored --lp- token(s) in src/. Use generic Pragma tokens instead.' >&2; exit 1; } || test $? -eq 1",
+    "check:styles": "grep -rIn --include='*.svelte' -e '<style' src/lib/components/ && { echo 'Found <style> block in a component. Put styles in a co-located styles.css.' >&2; exit 1; } || test $? -eq 1",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check .",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare": "svelte-kit sync; husky",
     "svelte-check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "svelte-check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "check:tokens": "! grep -rIn --include='*.svelte' --include='*.css' -- '--lp-' src/",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check .",


### PR DESCRIPTION
## Done
Made the Pragma design-system rules discoverable before UI work starts and enforces the core rule so it can't rot:
  - AGENTS.md: pointer telling any UI/styling work to read the Pragma doc first.
  - check:tokens: script that fails if any authored --lp-* token appears in src/ (scoped to .svelte/.css);
  wired into the CI lint job.

## How to QA
NA
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-37842
